### PR TITLE
Fix exported symbol detection on macOS

### DIFF
--- a/xtask/src/symbols.rs
+++ b/xtask/src/symbols.rs
@@ -26,7 +26,7 @@ pub fn exported<P: AsRef<Path>>(binary: P, symbol: &str) -> Result<bool> {
             // XXX: Why are all exported symbols on macOS prefixed with an underscore?
             let symbol = format!("_{}", symbol);
 
-            Ok(obj.exports()?.into_iter().any(|sym| sym.name == symbol))
+            Ok(obj.symbols().any(|r| r.map_or(false, |x| x.0 == symbol)))
         }
         goblin::Object::PE(obj) => Ok(obj.exports.iter().any(|sym| sym.name == Some(symbol))),
         obj => bail!("Unsupported object type: {:?}", obj),


### PR DESCRIPTION
Since the replacement of `--bundle-vst3` with export detection, at least on my machine, running

```
cargo xtask bundle gain_gui --release
```

results in `Not creating any plugin bundles because the package does not export any plugins`.

This diff fixes that.