### PR TITLE
Fix exported symbol detection, pt2

### DIFF
--- a/xtask/src/symbols.rs
+++ b/xtask/src/symbols.rs
@@ -26,7 +26,11 @@ pub fn exported<P: AsRef<Path>>(binary: P, symbol: &str) -> Result<bool> {
             // XXX: Why are all exported symbols on macOS prefixed with an underscore?
             let symbol = format!("_{}", symbol);
 
-            Ok(obj.exports()?.into_iter().any(|sym| sym.name == symbol))
+            Ok(obj.symbols().any(|r| {
+                r.map_or(false, |x| {
+                    x.1.is_global() && !x.1.is_undefined() && x.0 == symbol
+                })
+            }))
         }
         goblin::Object::PE(obj) => Ok(obj.exports.iter().any(|sym| sym.name == Some(symbol))),
         obj => bail!("Unsupported object type: {:?}", obj),


### PR DESCRIPTION
Supersedes #2.

I closed #2 because it doesn't make sense to check all symbols in a function supposed to check exported symbols, does it? 🤦‍♂️
However, using `x.1.is_global() && !x.1.is_undefined()` filters the symbols down to:

```
_GetPluginFactory
_bundleEntry
_bundleExit
_cg_event_tap_callback_internal
_rust_eh_personality
```

That matches the output of [nm -gU target/release/libgain_gui.dylib](https://stackoverflow.com/questions/4506121/how-to-print-a-list-of-symbols-exported-from-a-dynamic-library):

```
0000000000016af0 T _GetPluginFactory
0000000000016b00 T _bundleEntry
0000000000016b10 T _bundleExit
00000000000abaa0 T _cg_event_tap_callback_internal
00000000000daef0 T _rust_eh_personality
```

Unfortunately, I don't have a machine running `10.15` (CI version) to see if it works there...