### PR TITLE
Fix compilation errors when SSE not available

### DIFF
--- a/src/wrapper/util.rs
+++ b/src/wrapper/util.rs
@@ -120,8 +120,8 @@ impl ScopedFtz {
                 }
             } else {
                 Self {
-                    old_ftz_mode: None,
-                    send_sync_marker: PhantomData,
+                    should_disable_again: false,
+                    _send_sync_marker: PhantomData,
                 }
             }
         }


### PR DESCRIPTION
Looks like these were missed in https://github.com/robbert-vdh/nih-plug/commit/7d3beb174e59773cfa676267e4eb9e51c7085222 and https://github.com/robbert-vdh/nih-plug/commit/d878fd692a0a7e3a26c97d29daeec791be5c2436.