### PR TITLE
[nih_plug_xtask] Fix chdir_workspace_root()

### DIFF
--- a/nih_plug_xtask/src/lib.rs
+++ b/nih_plug_xtask/src/lib.rs
@@ -103,7 +103,8 @@ pub fn main_with_args(command_name: &str, mut args: impl Iterator<Item = String>
 
 /// Change the current directory into the Cargo workspace's root.
 pub fn chdir_workspace_root() -> Result<()> {
-    let project_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+    let cargo_manifest_dir = std::env::var("CARGO_MANIFEST_DIR")?;
+    let project_root = Path::new(&cargo_manifest_dir)
         .parent()
         .context("Could not find project root")?;
     std::env::set_current_dir(project_root).context("Could not change to project root directory")


### PR DESCRIPTION
Hi, thanks to develop this project!

I tried to create a plugin with `nih-plug` and I've found that `nih_plug_xtask` failed to find my plugin project because `nih_plug_xtask` opens its own directory.

I fixed it by replacing `env!` with `std::env::var` to get `CARGO_MANIFEST_DIR` in runtime rather than compile time.