### PR TITLE
fix typoed AArch64 as ARM64

### DIFF
--- a/nih_plug_xtask/src/lib.rs
+++ b/nih_plug_xtask/src/lib.rs
@@ -420,7 +420,7 @@ fn compilation_target(cross_compile_target: Option<&str>) -> Result<CompilationT
             #[cfg(target_arch = "x86_64")]
             let architecture = Architecture::X86_64;
             #[cfg(target_arch = "aarch64")]
-            let architecture = Architecture::ARM64;
+            let architecture = Architecture::AArch64;
 
             #[cfg(target_os = "linux")]
             return Ok(CompilationTarget::Linux(architecture));


### PR DESCRIPTION
[here](https://github.com/robbert-vdh/nih-plug/blob/f7bfbb8d9553fc2ae72fdfa1e0f23583a36d52ff/nih_plug_xtask/src/lib.rs#L49) it is written as `Architecture::AArch64`, but [later down in the code](https://github.com/robbert-vdh/nih-plug/blob/f7bfbb8d9553fc2ae72fdfa1e0f23583a36d52ff/nih_plug_xtask/src/lib.rs#L423) it uses `Architecture::ARM64` which doesn't exist, failing the build when building on/for an Apple silicon mac.