### PR TITLE
Fix off-by-1 error in VST3 parameter range

### DIFF
--- a/src/wrapper/vst3/util.rs
+++ b/src/wrapper/vst3/util.rs
@@ -16,8 +16,8 @@ pub const VST3_MIDI_NUM_PARAMS: u32 = VST3_MIDI_CCS * VST3_MIDI_CHANNELS;
 /// plugin's parameters overlap with this range. The mapping to a parameter index is
 /// `VST3_MIDI_PARAMS_START + (cc_idx + (channel * VST3_MIDI_CCS))`.
 pub const VST3_MIDI_PARAMS_START: u32 = VST3_MIDI_PARAMS_END - VST3_MIDI_NUM_PARAMS;
-/// The (exlucive) end of the MIDI CC parameter range. Anything above this is reserved by the host.
-pub const VST3_MIDI_PARAMS_END: u32 = (1 << 31) + 1;
+/// The (exclusive) end of the MIDI CC parameter range. Anything above this is reserved by the host.
+pub const VST3_MIDI_PARAMS_END: u32 = 1 << 31;
 
 /// Early exit out of a VST3 function when one of the passed pointers is null
 macro_rules! check_null_ptr {


### PR DESCRIPTION
Running the [VST3 SDK Validator](https://github.com/steinbergmedia/vst3_public_sdk/tree/55d7ed3c6a25496b41fc4440aaad4fae1b967d37/samples/vst-hosting/validator) for the `midi_inverter` plugin shows one failing test:

    [Scan Parameters]
    Info:  ===Scan Parameters ====================================
    Info:  This component exports 2080 parameter(s)
    Info:     Parameter 000 (id=2147481569): [title="MIDI Ch. 1 CC 0"] [unit=""] [type = F, default = 0.000000, unit = 0]
    Info:     Parameter 001 (id=2147481570): [title="MIDI Ch. 1 CC 1"] [unit=""] [type = F, default = 0.000000, unit = 0]
    Info:     Parameter 002 (id=2147481571): [title="MIDI Ch. 1 CC 2"] [unit=""] [type = F, default = 0.000000, unit = 0]

[...]

    Info:     Parameter 2077 (id=2147483646): [title="MIDI Ch. 16 CC 127"] [unit=""] [type = F, default = 0.000000, unit = 0]
    Info:     Parameter 2078 (id=2147483647): [title="MIDI Ch. 16 Channel Pressure"] [unit=""] [type = F, default = 0.000000, unit = 0]
    ERROR: =>Parameter 2079 (id=-2147483648): Invalid Id!!!
    [XXXXXXX Failed]

The [relevant part of the test code](https://github.com/steinbergmedia/vst3_public_sdk/blob/55d7ed3c6a25496b41fc4440aaad4fae1b967d37/source/vst/testsuite/general/scanparameters.cpp#L100) looks like this:

```c
int32 paramId = paramInfo.id;
if (paramId < 0)
{
    // Error
}
```

This shows that the parameter ID must be `INT32_MAX` = `(1 << 31) - 1` at most. As far as I see, even [Steinberg's own documentation](https://steinbergmedia.github.io/vst3_dev_portal/pages/Technical+Documentation/Parameters+Automation/Index.html) gets this wrong.