### PR TITLE
Fix some typos

### DIFF
--- a/plugins/examples/gain/src/lib.rs
+++ b/plugins/examples/gain/src/lib.rs
@@ -80,7 +80,7 @@ impl Default for GainParams {
             // `.with_step_size(0.1)` function to get internal rounding.
             .with_value_to_string(formatters::v2s_f32_gain_to_db(2))
             .with_string_to_value(formatters::s2v_f32_gain_to_db()),
-            // Persisted fields can be intialized like any other fields, and they'll keep their
+            // Persisted fields can be initialized like any other fields, and they'll keep their
             // values when restoring the plugin's state.
             random_data: RwLock::new(Vec::new()),
             sub_params: SubParams {

--- a/plugins/examples/gain/src/lib.rs
+++ b/plugins/examples/gain/src/lib.rs
@@ -12,7 +12,7 @@ struct Gain {
 /// of a parameters struct for multiple identical oscillators/filters/envelopes.
 #[derive(Params)]
 struct GainParams {
-    /// The parameter's ID is used to identify the parameter in the wrappred plugin API. As long as
+    /// The parameter's ID is used to identify the parameter in the wrapped plugin API. As long as
     /// these IDs remain constant, you can rename and reorder these fields as you wish. The
     /// parameters are exposed to the host in the same order they were defined. In this case, this
     /// gain parameter is stored as linear gain while the values are displayed in decibels.

--- a/plugins/spectral_compressor/src/compressor_bank.rs
+++ b/plugins/spectral_compressor/src/compressor_bank.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 
 use crate::SpectralCompressorParams;
 
-// These are the parameter ID prefixes used for the downwards and upwards cmpression parameters.
+// These are the parameter ID prefixes used for the downwards and upwards compression parameters.
 const DOWNWARDS_NAME_PREFIX: &str = "downwards_";
 const UPWARDS_NAME_PREFIX: &str = "upwards_";
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -17,8 +17,8 @@ pub use samples::{ChannelSamples, ChannelSamplesIter, SamplesIter};
 ///       this either way. Maybe just get rid of it in favor for raw pointers.
 #[derive(Default)]
 pub struct Buffer<'a> {
-    /// Contains slices for the plugin's outputs. You can't directly create a nested slice form
-    /// apointer to pointers, so this needs to be preallocated in the setup call and kept around
+    /// Contains slices for the plugin's outputs. You can't directly create a nested slice from a
+    /// pointer to pointers, so this needs to be preallocated in the setup call and kept around
     /// between process calls. And because storing a reference to this means a) that you need a lot
     /// of lifetime annotations everywhere and b) that at some point you need unsound lifetime casts
     /// because this `Buffers` either cannot have the same lifetime as the separately stored output
@@ -28,7 +28,7 @@ pub struct Buffer<'a> {
 }
 
 impl<'a> Buffer<'a> {
-    /// Returns the numer of samples in this buffer.
+    /// Returns the number of samples in this buffer.
     #[inline]
     pub fn len(&self) -> usize {
         if self.output_slices.is_empty() {
@@ -38,7 +38,7 @@ impl<'a> Buffer<'a> {
         }
     }
 
-    /// Returns the numer of channels in this buffer.
+    /// Returns the number of channels in this buffer.
     #[inline]
     pub fn channels(&self) -> usize {
         self.output_slices.len()
@@ -76,7 +76,7 @@ impl<'a> Buffer<'a> {
 
     /// Iterate over the buffer in blocks with the specified maximum size. The ideal maximum block
     /// size depends on the plugin in question, but 64 or 128 samples works for most plugins. Since
-    /// the buffer's total size may not be cleanly divisble by the maximum size, the returned
+    /// the buffer's total size may not be cleanly divisible by the maximum size, the returned
     /// buffers may have any size in `[1, max_block_size]`. This is useful when using algorithms
     /// that work on entire blocks of audio, like those that would otherwise need to perform
     /// expensive per-sample branching or that can use per-sample SIMD as opposed to per-channel

--- a/src/buffer/blocks.rs
+++ b/src/buffer/blocks.rs
@@ -131,7 +131,7 @@ impl<'slice, 'sample> Block<'slice, 'sample> {
         self.current_block_end - self.current_block_start
     }
 
-    /// Returns the numer of channels in this buffer.
+    /// Returns the number of channels in this buffer.
     #[inline]
     pub fn channels(&self) -> usize {
         unsafe { (*self.buffers).len() }

--- a/src/context.rs
+++ b/src/context.rs
@@ -179,7 +179,7 @@ pub struct Transport {
     /// [`Plugin::initialize()`][crate::prelude::Plugin::initialize()], so if you need this then you
     /// can also store that value.
     pub sample_rate: f32,
-    /// The proejct's tempo in beats per minute.
+    /// The project's tempo in beats per minute.
     pub tempo: Option<f64>,
     /// The time signature's numerator.
     pub time_sig_numerator: Option<i32>,
@@ -206,15 +206,15 @@ pub struct Transport {
 
     /// The loop range in samples, if the loop is active and this information is available. None of
     /// the plugin API docs mention whether this is exclusive or inclusive, but just assume that the
-    /// end is exclusive. Can be calulcated from the other loop range information if needed.
+    /// end is exclusive. Can be calculated from the other loop range information if needed.
     pub(crate) loop_range_samples: Option<(i64, i64)>,
     /// The loop range in seconds, if the loop is active and this information is available. None of
     /// the plugin API docs mention whether this is exclusive or inclusive, but just assume that the
-    /// end is exclusive. Can be calulcated from the other loop range information if needed.
+    /// end is exclusive. Can be calculated from the other loop range information if needed.
     pub(crate) loop_range_seconds: Option<(f64, f64)>,
     /// The loop range in quarter notes, if the loop is active and this information is available.
     /// None of the plugin API docs mention whether this is exclusive or inclusive, but just assume
-    /// that the end is exclusive. Can be calulcated from the other loop range information if
+    /// that the end is exclusive. Can be calculated from the other loop range information if
     /// needed.
     pub(crate) loop_range_beats: Option<(f64, f64)>,
 }
@@ -440,7 +440,7 @@ impl<'a> ParamSetter<'a> {
         }
     }
 
-    /// Inform the host that you will start automating a parmater. This needs to be called before
+    /// Inform the host that you will start automating a parameter. This needs to be called before
     /// calling [`set_parameter()`][Self::set_parameter()] for the specified parameter.
     pub fn begin_set_parameter<P: Param>(&self, param: &P) {
         unsafe { self.raw_context.raw_begin_set_parameter(param.as_ptr()) };

--- a/src/event_loop/linux.rs
+++ b/src/event_loop/linux.rs
@@ -53,7 +53,7 @@ where
         Self {
             executor: executor.clone(),
             main_thread_id: thread::current().id(),
-            // With our drop implementation we guarentee that this thread never outlives this struct
+            // With our drop implementation we guarantee that this thread never outlives this struct
             worker_thread: Some(
                 thread::Builder::new()
                     .name(String::from("worker"))
@@ -88,7 +88,7 @@ where
 
     fn is_main_thread(&self) -> bool {
         // FIXME: `thread::current()` may allocate the first time it's called, is there a safe
-        //        nonallocating version of this without using huge OS-specific libraries?
+        //        non-allocating version of this without using huge OS-specific libraries?
         permit_alloc(|| thread::current().id() == self.main_thread_id)
     }
 }

--- a/src/event_loop/linux.rs
+++ b/src/event_loop/linux.rs
@@ -104,7 +104,7 @@ impl<T, E> Drop for LinuxEventLoop<T, E> {
     }
 }
 
-/// The worker thread used in [`EventLoop`] that executes incmoing tasks on the event loop's
+/// The worker thread used in [`EventLoop`] that executes incoming tasks on the event loop's
 /// executor.
 fn worker_thread<T, E>(receiver: channel::Receiver<Message<T>>, executor: Weak<E>)
 where

--- a/src/event_loop/windows.rs
+++ b/src/event_loop/windows.rs
@@ -26,10 +26,10 @@ use crate::util::permit_alloc;
 const NOTIFY_MESSAGE_ID: u32 = WM_USER;
 
 /// A type erased function passed to the window so it can poll for events. We can't pass the tasks
-/// queue and executor to the window callback sicne the callback wouldn't know what types they are,
+/// queue and executor to the window callback since the callback wouldn't know what types they are,
 /// but we can wrap the polling loop in a closure and pass that instead.
 ///
-/// This needs to be double boxed when passed to the function since fat pointers canont be directly
+/// This needs to be double boxed when passed to the function since fat pointers cannot be directly
 /// casted from a regular pointer.
 type PollCallback = Box<dyn Fn()>;
 
@@ -45,7 +45,7 @@ pub(crate) struct WindowsEventLoop<T, E> {
     main_thread_id: ThreadId,
 
     /// An invisible window that we can post a message to when we need to do something on the main
-    /// thread. The host's message loop will then cause our message to be proceded.
+    /// thread. The host's message loop will then cause our message to be proceeded.
     message_window: HWND,
     /// The unique class for the message window, we'll clean this up together with the window.
     message_window_class_name: CString,

--- a/src/event_loop/windows.rs
+++ b/src/event_loop/windows.rs
@@ -116,8 +116,8 @@ where
                 HWND(0),
                 HMENU(0),
                 HINSTANCE(0),
-                // NOTE: We're boxing a box here. As mentioend in [PollCallback], we c an't directly
-                //       pass around fat poitners, so we need a normal pointer to a fat pointer to
+                // NOTE: We're boxing a box here. As mentioned in [PollCallback], we can't directly
+                //       pass around fat pointers, so we need a normal pointer to a fat pointer to
                 //       be able to call this and deallocate it later
                 Box::into_raw(Box::new(callback)) as *const c_void,
             )
@@ -164,7 +164,7 @@ where
 
     fn is_main_thread(&self) -> bool {
         // FIXME: `thread::current()` may allocate the first time it's called, is there a safe
-        //        nonallocating version of this without using huge OS-specific libraries?
+        //        non-allocating version of this without using huge OS-specific libraries?
         permit_alloc(|| thread::current().id() == self.main_thread_id)
     }
 }

--- a/src/formatters.rs
+++ b/src/formatters.rs
@@ -1,7 +1,7 @@
 //! Convenience functions for formatting and parsing parameter values in various common formats.
 //!
 //! Functions prefixed with `v2s_` are meant to be used with the `.value_to_string()` parameter
-//! fucntions, while the `s2v_` functions are meant to be used wit the `.string_to_value()`.
+//! functions, while the `s2v_` functions are meant to be used wit the `.string_to_value()`.
 //! functions. Most of these formatters come as a pair. Check each formatter's documentation for any
 //! additional usage information.
 
@@ -203,7 +203,7 @@ pub fn s2v_i32_note_formatter() -> Arc<dyn Fn(&str) -> Option<i32> + Send + Sync
 }
 
 /// Display 'Bypassed' or 'Not Bypassed' depending on whether the parameter is true or false.
-/// 'Enabled' would have also been a possibilty here, but that could be a bit confusing.
+/// 'Enabled' would have also been a possibility here, but that could be a bit confusing.
 pub fn v2s_bool_bypass() -> Arc<dyn Fn(bool) -> String + Send + Sync> {
     Arc::new(move |value| {
         if value {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //!   debugger is attached, in which case the output is logged to the debug console instead. The
 //!   `NIH_LOG` environment variable controls whether output is logged to STDERR, the Windows debug
 //!   console, or to a file. Check the [`nih_log!()`] macro for more information.
-//! - The abovementioned debug module also contains non-fatal debug-assertions macros that are only
+//! - The aforementioned debug module also contains non-fatal debug-assertions macros that are only
 //!   evaluated during debug builds. The framework uses these all over the place to check for
 //!   invariants, so it's important to test your plugins using debug builds while developing.
 //! - Check out the features list in NIH-plug's `Cargo.toml` file for optional features you can
@@ -38,7 +38,7 @@
 //!      calculations or IO at this point.
 //!   2. The host or the plugin wrapper will call
 //!      [`Plugin::accepts_bus_config()`][prelude::Plugin::accepts_bus_config()] several times with
-//!      different IO configuratinos to poll whether your plugin supports certain IO configurations.
+//!      different IO configurations to poll whether your plugin supports certain IO configurations.
 //!      The plugin should not do any work at this point and just reply with boolean whether it
 //!      supports the configuration or not.
 //!   3. After that, [`Plugin::initialize()`][prelude::Plugin::initialize()] will be called with the
@@ -78,7 +78,7 @@
 //!    out the [`Smoother`][prelude::Smoother] API for more details.
 //!
 //! There's a whole lot more to discuss, but once you understand the above you should be able to
-//! figure out the rest by reading through the examples and the API documetnation. Good luck!
+//! figure out the rest by reading through the examples and the API documentation. Good luck!
 
 #![cfg_attr(feature = "docs", feature(doc_auto_cfg))]
 #![cfg_attr(feature = "simd", feature(portable_simd))]

--- a/src/midi.rs
+++ b/src/midi.rs
@@ -98,7 +98,7 @@ pub enum NoteEvent {
     ///   monophonic modulation. This is `parameter.value` for unsmoothed parameters, and smoothed
     ///   parameters should use block smoothing so the smoothed values can be reused by multiple
     ///   voices.
-    /// - If a `PolyModulation` event is emited for the voice, that voice should use the the
+    /// - If a `PolyModulation` event is emitted for the voice, that voice should use the the
     ///   _normalized offset_ contained within the event to compute the voice's modulated value and
     ///   use that in place of the global value.
     ///   - This value can be obtained by calling `param.preview_plain(param.normalized_value() +
@@ -137,9 +137,9 @@ pub enum NoteEvent {
         normalized_offset: f32,
     },
     /// A notification to inform the plugin that a polyphonically modulated parameter has received a
-    /// new automation value. This is used in conjuction with the `PolyModulation` event. See that
+    /// new automation value. This is used in conjunction with the `PolyModulation` event. See that
     /// event's documentation for more details. The parameter's global value has already been
-    /// updated when this event is emited.
+    /// updated when this event is emitted.
     MonoAutomation {
         timing: u32,
         /// The ID that was set for the modulated parameter using the `.with_poly_modulation_id()`

--- a/src/param.rs
+++ b/src/param.rs
@@ -103,7 +103,7 @@ pub trait Param: Display {
         self.preview_normalized(self.default_plain_value())
     }
 
-    /// Get the number of steps for this paramter, if it is discrete. Used for the host's generic
+    /// Get the number of steps for this parameter, if it is discrete. Used for the host's generic
     /// UI.
     fn step_count(&self) -> Option<usize>;
 

--- a/src/param/boolean.rs
+++ b/src/param/boolean.rs
@@ -184,7 +184,7 @@ impl ParamMut for BoolParam {
     fn set_normalized_value(&self, normalized: f32) {
         // NOTE: The double conversion here is to make sure the state is reproducible. State is
         //       saved and restored using plain values, and the new normalized value will be
-        //       different from `normalized`. This is not necesasry for the modulation as these
+        //       different from `normalized`. This is not necessary for the modulation as these
         //       values are never shown to the host.
         self.set_plain_value(self.preview_plain(normalized))
     }

--- a/src/param/boolean.rs
+++ b/src/param/boolean.rs
@@ -21,7 +21,7 @@ pub struct BoolParam {
     /// from the host has been applied. This will always be the same as `value` for VST3 plugins.
     unmodulated_normalized_value: AtomicF32,
     /// A value in `[-1, 1]` indicating the amount of modulation applied to
-    /// `unmodulated_normalized_`. This needs to be stored separately since the normalied values are
+    /// `unmodulated_normalized_`. This needs to be stored separately since the normalized values are
     /// clamped, and this value persists after new automation events.
     modulation_offset: AtomicF32,
     /// The field's default value.
@@ -286,7 +286,7 @@ impl BoolParam {
         self
     }
 
-    /// Mark the paramter as non-automatable. This means that the parameter cannot be changed from
+    /// Mark the parameter as non-automatable. This means that the parameter cannot be changed from
     /// an automation lane. The parameter can however still be manually changed by the user from
     /// either the plugin's own GUI or from the host's generic UI.
     pub fn non_automatable(mut self) -> Self {

--- a/src/param/enums.rs
+++ b/src/param/enums.rs
@@ -63,7 +63,7 @@ pub trait Enum {
 
     /// Get the variant corresponding to the variant with the same index in
     /// [`variants()`][Self::variants()]. This must always return a value. If the index is out of
-    /// range, return the first variatn.
+    /// range, return the first variant.
     fn from_index(index: usize) -> Self;
 }
 
@@ -360,7 +360,7 @@ impl<T: Enum + PartialEq + 'static> EnumParam<T> {
         self
     }
 
-    /// Mark the paramter as non-automatable. This means that the parameter cannot be changed from
+    /// Mark the parameter as non-automatable. This means that the parameter cannot be changed from
     /// an automation lane. The parameter can however still be manually changed by the user from
     /// either the plugin's own GUI or from the host's generic UI.
     pub fn non_automatable(mut self) -> Self {

--- a/src/param/float.rs
+++ b/src/param/float.rs
@@ -218,7 +218,7 @@ impl ParamMut for FloatParam {
     fn set_normalized_value(&self, normalized: f32) {
         // NOTE: The double conversion here is to make sure the state is reproducible. State is
         //       saved and restored using plain values, and the new normalized value will be
-        //       different from `normalized`. This is not necesasry for the modulation as these
+        //       different from `normalized`. This is not necessary for the modulation as these
         //       values are never shown to the host.
         self.set_plain_value(self.preview_plain(normalized))
     }
@@ -294,7 +294,7 @@ impl FloatParam {
     /// clicks and zipper noises.
     pub fn with_smoother(mut self, style: SmoothingStyle) -> Self {
         // Logarithmic smoothing will cause problems if the range goes through zero since then you
-        // end up multplying by zero
+        // end up multiplying by zero
         let goes_through_zero = match (&style, &self.range) {
             (
                 SmoothingStyle::Logarithmic(_),

--- a/src/param/float.rs
+++ b/src/param/float.rs
@@ -24,7 +24,7 @@ pub struct FloatParam {
     /// from the host has been applied. This will always be the same as `value` for VST3 plugins.
     unmodulated_normalized_value: AtomicF32,
     /// A value in `[-1, 1]` indicating the amount of modulation applied to
-    /// `unmodulated_normalized_`. This needs to be stored separately since the normalied values are
+    /// `unmodulated_normalized_`. This needs to be stored separately since the normalized values are
     /// clamped, and this value persists after new automation events.
     modulation_offset: AtomicF32,
     /// The field's default plain, unnormalized value.
@@ -39,7 +39,7 @@ pub struct FloatParam {
     /// the parameter's new **plain** value. This should not do anything expensive as it may be
     /// called multiple times in rapid succession.
     ///
-    /// To use this, you'll probably want to store an `Arc<Atomic*>` alongside the parmater in the
+    /// To use this, you'll probably want to store an `Arc<Atomic*>` alongside the parameter in the
     /// parameters struct, move a clone of that `Arc` into this closure, and then modify that.
     ///
     /// TODO: We probably also want to pass the old value to this function.
@@ -363,7 +363,7 @@ impl FloatParam {
         self
     }
 
-    /// Mark the paramter as non-automatable. This means that the parameter cannot be changed from
+    /// Mark the parameter as non-automatable. This means that the parameter cannot be changed from
     /// an automation lane. The parameter can however still be manually changed by the user from
     /// either the plugin's own GUI or from the host's generic UI.
     pub fn non_automatable(mut self) -> Self {
@@ -387,7 +387,7 @@ impl FloatParam {
     }
 }
 
-/// Caldculate how many decimals to round to when displaying a floating point value with a specific
+/// Calculate how many decimals to round to when displaying a floating point value with a specific
 /// step size. We'll perform some rounding to ignore spurious extra precision caused by the floating
 /// point quantization.
 fn decimals_from_step_size(step_size: f32) -> usize {

--- a/src/param/integer.rs
+++ b/src/param/integer.rs
@@ -198,7 +198,7 @@ impl ParamMut for IntParam {
     fn set_normalized_value(&self, normalized: f32) {
         // NOTE: The double conversion here is to make sure the state is reproducible. State is
         //       saved and restored using plain values, and the new normalized value will be
-        //       different from `normalized`. This is not necesasry for the modulation as these
+        //       different from `normalized`. This is not necessary for the modulation as these
         //       values are never shown to the host.
         self.set_plain_value(self.preview_plain(normalized))
     }
@@ -273,7 +273,7 @@ impl IntParam {
     /// clicks and zipper noises.
     pub fn with_smoother(mut self, style: SmoothingStyle) -> Self {
         // Logarithmic smoothing will cause problems if the range goes through zero since then you
-        // end up multplying by zero
+        // end up multiplying by zero
         let goes_through_zero = match (&style, &self.range) {
             (SmoothingStyle::Logarithmic(_), IntRange::Linear { min, max }) => {
                 *min == 0 || *max == 0 || min.signum() != max.signum()

--- a/src/param/integer.rs
+++ b/src/param/integer.rs
@@ -24,7 +24,7 @@ pub struct IntParam {
     /// from the host has been applied. This will always be the same as `value` for VST3 plugins.
     unmodulated_normalized_value: AtomicF32,
     /// A value in `[-1, 1]` indicating the amount of modulation applied to
-    /// `unmodulated_normalized_`. This needs to be stored separately since the normalied values are
+    /// `unmodulated_normalized_`. This needs to be stored separately since the normalized values are
     /// clamped, and this value persists after new automation events.
     modulation_offset: AtomicF32,
     /// The field's default plain, unnormalized value.
@@ -39,7 +39,7 @@ pub struct IntParam {
     /// the parameter's new **plain** value. This should not do anything expensive as it may be
     /// called multiple times in rapid succession.
     ///
-    /// To use this, you'll probably want to store an `Arc<Atomic*>` alongside the parmater in the
+    /// To use this, you'll probably want to store an `Arc<Atomic*>` alongside the parameter in the
     /// parameters struct, move a clone of that `Arc` into this closure, and then modify that.
     ///
     /// TODO: We probably also want to pass the old value to this function.
@@ -332,7 +332,7 @@ impl IntParam {
         self
     }
 
-    /// Mark the paramter as non-automatable. This means that the parameter cannot be changed from
+    /// Mark the parameter as non-automatable. This means that the parameter cannot be changed from
     /// an automation lane. The parameter can however still be manually changed by the user from
     /// either the plugin's own GUI or from the host's generic UI.
     pub fn non_automatable(mut self) -> Self {

--- a/src/param/internals.rs
+++ b/src/param/internals.rs
@@ -39,7 +39,7 @@ pub mod serialize_atomic_cell {
 /// This trait can be derived on a struct containing [`FloatParam`][super::FloatParam] and other
 /// parameter fields. When deriving this trait, any of those parameter fields should have the `#[id
 /// = "stable"]` attribute, where `stable` is an up to 6 character long string (to avoid collisions)
-/// that will be used to identify the parameter internall so you can safely move it around and
+/// that will be used to identify the parameter internally so you can safely move it around and
 /// rename the field without breaking compatibility with old presets.
 ///
 /// The struct can also contain other fields that should be persisted along with the rest of the
@@ -50,7 +50,7 @@ pub mod serialize_atomic_cell {
 /// And finally when deriving this trait, it is also possible to inherit the parameters from other
 /// `Params` objects by adding the `#[nested = "Group Name"]` attribute to those fields. These
 /// groups will be displayed as a tree-like structure if your DAW supports it. Parameter IDs and
-/// persisting keys still need to be **unique** when usting nested parameter structs. This currently
+/// persisting keys still need to be **unique** when using nested parameter structs. This currently
 /// has the following caveats:
 ///
 /// - Enforcing that parameter IDs and persist keys are unique does not work across nested structs.
@@ -71,13 +71,13 @@ pub unsafe trait Params: 'static + Send + Sync {
     /// exist or you may encounter panics. The derive macro does this for every parameter field
     /// marked with `#[id = "stable"]`, and it also inlines all fields from nested child `Params`
     /// structs marked with `#[nested = "Group Name"]` while prefixing that group name before the
-    /// parameter's originanl group name. Dereferencing the pointers stored in the values is only
+    /// parameter's original group name. Dereferencing the pointers stored in the values is only
     /// valid as long as this object is valid.
     ///
     /// # Note
     ///
     /// This uses `String` even though for the `Params` derive macro `&'static str` would have been
-    /// fine to be able to support custom reusable Params implemnetations.
+    /// fine to be able to support custom reusable Params implementations.
     fn param_map(&self) -> Vec<(String, ParamPtr, String)>;
 
     /// Serialize all fields marked with `#[persist = "stable_name"]` into a hash map containing
@@ -88,7 +88,7 @@ pub unsafe trait Params: 'static + Send + Sync {
     }
 
     /// Restore all fields marked with `#[persist = "stable_name"]` from a hashmap created by
-    /// [`serialize_fields()`][Self::serialize_fields()]. All of thse fields should be wrapped in a
+    /// [`serialize_fields()`][Self::serialize_fields()]. All of these fields should be wrapped in a
     /// [`PersistentField`] with thread safe interior mutability, like an `RwLock` or a `Mutex`.
     /// This gets called when the plugin's state is being restored. This uses [deserialize_field()]
     /// under the hood.

--- a/src/param/range.rs
+++ b/src/param/range.rs
@@ -86,7 +86,7 @@ impl FloatRange {
                     (scaled_proportion.powf(*factor) * 0.5) + 0.5
                 } else {
                     // The part below the center gets scaled, inverted (so the range is [0, 1] where
-                    // 0 corresponds to the center proportion and 1 corresponds to the orignal
+                    // 0 corresponds to the center proportion and 1 corresponds to the original
                     // normalized 0 value), skewed, inverted back again, and then scaled back to the
                     // original range
                     let inverted_scaled_proportion =
@@ -137,7 +137,7 @@ impl FloatRange {
         // range up into 100 segments, but if `self.step_size` is set then we'll use that. Ideally
         // we might want to split the range up into at most 100 segments, falling back to the step
         // size if the total number of steps would be smaller than that, but since ranges can be
-        // nonlienar that's a bit difficult to pull off.
+        // nonlinear that's a bit difficult to pull off.
         // TODO: At some point, implement the above mentioned step size quantization
         match self {
             FloatRange::Linear { min, max }

--- a/src/param/range.rs
+++ b/src/param/range.rs
@@ -167,7 +167,7 @@ impl FloatRange {
         }
     }
 
-    /// Snap a vlue to a step size, clamping to the minimum and maximum value of the range.
+    /// Snap a value to a step size, clamping to the minimum and maximum value of the range.
     pub fn snap_to_step(&self, value: f32, step_size: f32) -> f32 {
         match self {
             FloatRange::Linear { min, max }

--- a/src/param/smoothing.rs
+++ b/src/param/smoothing.rs
@@ -539,7 +539,7 @@ mod tests {
 
     /// Applying `next()` `n` times should be the same as `next_step()` for `n` steps.
     #[test]
-    fn linear_f32_next_equivalance() {
+    fn linear_f32_next_equivalence() {
         let style = SmoothingStyle::Linear(100.0);
 
         let mut current = 0.4;
@@ -556,7 +556,7 @@ mod tests {
     }
 
     #[test]
-    fn logarithmic_f32_next_equivalance() {
+    fn logarithmic_f32_next_equivalence() {
         let style = SmoothingStyle::Logarithmic(100.0);
 
         let mut current = 0.4;
@@ -573,7 +573,7 @@ mod tests {
     }
 
     #[test]
-    fn exponential_f32_next_equivalance() {
+    fn exponential_f32_next_equivalence() {
         let style = SmoothingStyle::Exponential(100.0);
 
         let mut current = 0.4;

--- a/src/param/smoothing.rs
+++ b/src/param/smoothing.rs
@@ -109,7 +109,7 @@ impl SmoothingStyle {
                 ((target / start) as f64).powf((num_steps as f64).recip()) as f32
             }
             // In this case the step size value is the coefficient the current value will be
-            // multiplied by, while the target value is multipled by one minus the coefficient. This
+            // multiplied by, while the target value is multiplied by one minus the coefficient. This
             // reaches 99.99% of the target value after `num_steps`. The smoother will snap to the
             // target value after that point.
             SmoothingStyle::Exponential(_) => 0.0001f64.powf((num_steps as f64).recip()) as f32,
@@ -361,7 +361,7 @@ impl<T: Smoothable> Smoother<T> {
         let target = T::atomic_load(&self.target);
 
         // `self.next()` will yield the current value if the parameter is no longer smoothing, but
-        // it's a bit of a waste to continuesly call that if only the first couple or none of the
+        // it's a bit of a waste to continuously call that if only the first couple or none of the
         // values in `block_values` would require smoothing and the rest don't. Instead, we'll just
         // smooth the values as necessary, and then reuse the target value for the rest of the
         // block.

--- a/src/param/smoothing.rs
+++ b/src/param/smoothing.rs
@@ -47,7 +47,7 @@ pub struct Smoother<T: Smoothable> {
     /// uniform.
     ///
     /// In the case of the `Exponential` smoothing style this is the coefficient `x` that the
-    /// previous sample is multplied by.
+    /// previous sample is multiplied by.
     step_size: AtomicF32,
     /// The value for the current sample. Always stored as floating point for obvious reasons.
     current: AtomicF32,
@@ -119,7 +119,7 @@ impl SmoothingStyle {
     /// Compute the next value from `current` leading up to `target` using the `step_size` computed
     /// using [`SmoothingStyle::step_size()`]. Depending on the smoothing style this function may
     /// never completely reach `target`, so you will need to snap to `target` yourself after
-    /// cmoputing the target number of steps.
+    /// computing the target number of steps.
     ///
     /// See the docstring on the [`SmoothingStyle::next_step()`] function for the formulas used.
     #[inline]
@@ -229,7 +229,7 @@ impl<T: Smoothable> Smoother<T> {
     }
 
     /// Whether calling [`next()`][Self::next()] will yield a new value or an old value. Useful if
-    /// you need to recompute something wheenver this parameter changes.
+    /// you need to recompute something whenever this parameter changes.
     #[inline]
     pub fn is_smoothing(&self) -> bool {
         self.steps_left() > 0

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -264,7 +264,7 @@ pub trait Editor: Send + Sync {
     //       callback that deos involve actual GUI operations will still be spooled to the IRunLoop
     //       instance.
     // TODO: This function should return an `Option` instead. Right now window opening failures are
-    //       always fatal. This would need to be fixed in basevie first.
+    //       always fatal. This would need to be fixed in baseview first.
     fn spawn(
         &self,
         parent: ParentWindowHandle,

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -52,7 +52,7 @@ pub trait Plugin: Default + Send + Sync + 'static {
     /// configuration works the same was as with `DEFAULT_INPUT_CHANNELS`.
     const DEFAULT_AUX_INPUTS: Option<AuxiliaryIOConfig> = None;
     /// If set, then the plugin will have this many auxiliary output busses with a default number of
-    /// channels. Negotiating the actual configuration wroks the same was as with
+    /// channels. Negotiating the actual configuration works the same was as with
     /// `DEFAULT_INPUT_CHANNELS`.
     const DEFAULT_AUX_OUTPUTS: Option<AuxiliaryIOConfig> = None;
 
@@ -70,7 +70,7 @@ pub trait Plugin: Default + Send + Sync + 'static {
     /// is set to [`MidiConfig::None`], then the plugin won't receive any note events.
     const MIDI_INPUT: MidiConfig = MidiConfig::None;
     /// Whether the plugin can output note events. If this is set to [`MidiConfig::None`], then the
-    /// plugin won't have a note output port. When this is set to another value, then in most hsots
+    /// plugin won't have a note output port. When this is set to another value, then in most hosts
     /// the plugin will consume all note and MIDI CC input. If you don't want that, then you will
     /// need to forward those events yourself.
     const MIDI_OUTPUT: MidiConfig = MidiConfig::None;
@@ -117,14 +117,14 @@ pub trait Plugin: Default + Send + Sync + 'static {
     /// have already been restored at this point. If based on those parameters (or for any reason
     /// whatsoever) the plugin needs to introduce latency, then you can do so here using the process
     /// context. Depending on how the host restores plugin state, this function may also be called
-    /// twice in rapid succession. If the plugin fails to inialize for whatever reason, then this
+    /// twice in rapid succession. If the plugin fails to initialize for whatever reason, then this
     /// should return `false`.
     ///
     /// Before this point, the plugin should not have done any expensive initialization. Please
     /// don't be that plugin that takes twenty seconds to scan.
     ///
     /// After this function [`reset()`][Self::reset()] will always be called. If you need to clear
-    /// state, such as filters or envelopes, then you should do so in that function inistead.
+    /// state, such as filters or envelopes, then you should do so in that function instead.
     fn initialize(
         &mut self,
         bus_config: &BusConfig,
@@ -141,9 +141,9 @@ pub trait Plugin: Default + Send + Sync + 'static {
 
     /// Process audio. The host's input buffers have already been copied to the output buffers if
     /// they are not processing audio in place (most hosts do however). All channels are also
-    /// guarenteed to contain the same number of samples. Lastly, denormals have already been taken
+    /// guaranteed to contain the same number of samples. Lastly, denormals have already been taken
     /// case of by NIH-plug, and you can optionally enable the `assert_process_allocs` feature to
-    /// abort the program when any allocation accurs in the process function while running in debug
+    /// abort the program when any allocation occurs in the process function while running in debug
     /// mode.
     ///
     /// The framework provides convenient iterators on the [`Buffer`] object to process audio either
@@ -159,7 +159,7 @@ pub trait Plugin: Default + Send + Sync + 'static {
     /// auxiliary output buffers if it has any.
     ///
     /// TODO: Provide a way to access auxiliary input channels if the IO configuration is
-    ///       assymetric
+    ///       asymmetric
     fn process(
         &mut self,
         buffer: &mut Buffer,
@@ -205,7 +205,7 @@ pub trait Vst3Plugin: Plugin {
     /// This will be shuffled into a different byte order on Windows for project-compatibility.
     const VST3_CLASS_ID: [u8; 16];
     /// One or more categories, separated by pipe characters (`|`), up to 127 characters. Anything
-    /// logner than that will be truncated. See the VST3 SDK for examples of common categories:
+    /// longer than that will be truncated. See the VST3 SDK for examples of common categories:
     /// <https://github.com/steinbergmedia/vst3_pluginterfaces/blob/2ad397ade5b51007860bedb3b01b8afd2c5f6fba/vst/ivstaudioprocessor.h#L49-L90>
     //
     // TODO: Create a category enum similar to ClapFeature
@@ -271,7 +271,7 @@ pub trait Editor: Send + Sync {
         context: Arc<dyn GuiContext>,
     ) -> Box<dyn Any + Send + Sync>;
 
-    /// Returns the (currnent) size of the editor in pixels as a `(width, height)` pair. This size
+    /// Returns the (current) size of the editor in pixels as a `(width, height)` pair. This size
     /// must be reported in _logical pixels_, i.e. the size before being multiplied by the DPI
     /// scaling factor to get the actual physical screen pixels.
     fn size(&self) -> (u32, u32);
@@ -285,7 +285,7 @@ pub trait Editor: Send + Sync {
     /// there.
     fn set_scale_factor(&self, factor: f32) -> bool;
 
-    /// A callback that will be called wheneer the parameter values changed while the editor is
+    /// A callback that will be called whenever the parameter values changed while the editor is
     /// open. You don't need to do anything with this, but this can be used to force a redraw when
     /// the host sends a new value for a parameter or when a parameter change sent to the host gets
     /// processed.
@@ -325,7 +325,7 @@ pub struct BusConfig {
     pub aux_output_busses: AuxiliaryIOConfig,
 }
 
-/// Configuration for auxiliary inputs or outputs on [`BusCofnig`].
+/// Configuration for auxiliary inputs or outputs on [`BusConfig`].
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct AuxiliaryIOConfig {
     /// The number of auxiliary input or output busses.
@@ -389,7 +389,7 @@ pub enum ProcessStatus {
     Tail(u32),
     /// This plugin will continue to produce sound regardless of whether or not the input is silent,
     /// and should thus not be deactivated by the host. This is essentially the same as having an
-    /// infite tail.
+    /// infinite tail.
     KeepAlive,
 }
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,4 +1,4 @@
-// Re-export the macros, derive macros are already re-exported ferom their respectivem odules
+// Re-export the macros, derive macros are already re-exported from their respective modules
 pub use crate::debug::*;
 
 pub use crate::nih_export_clap;

--- a/src/util/stft.rs
+++ b/src/util/stft.rs
@@ -57,7 +57,7 @@ pub struct StftHelper<const NUM_SIDECHAIN_INPUTS: usize = 0> {
     padding: usize,
 }
 
-/// Marker struct for the version wtihout sidechaining.
+/// Marker struct for the version without sidechaining.
 struct NoSidechain;
 
 impl StftInput for Buffer<'_> {
@@ -255,7 +255,7 @@ impl<const NUM_SIDECHAIN_INPUTS: usize> StftHelper<NUM_SIDECHAIN_INPUTS> {
         self.main_input_ring_buffers.capacity()
     }
 
-    /// The amount of latency introduced when processing audio throug hthis [`StftHelper`].
+    /// The amount of latency introduced when processing audio through this [`StftHelper`].
     pub fn latency_samples(&self) -> u32 {
         self.main_input_ring_buffers[0].len() as u32
     }
@@ -496,7 +496,7 @@ impl<const NUM_SIDECHAIN_INPUTS: usize> StftHelper<NUM_SIDECHAIN_INPUTS> {
     /// Similar to [`process_overlap_add()`][Self::process_overlap_add()], but without the inverse
     /// STFT part. `buffer` will only ever be read from. This can be useful for providing FFT data
     /// for a spectrum analyzer in a plugin GUI. These is still a delay to the analysis equal to the
-    /// blcok size.
+    /// block size.
     pub fn process_analyze_only<B, F>(
         &mut self,
         buffer: &B,

--- a/src/util/window.rs
+++ b/src/util/window.rs
@@ -40,7 +40,7 @@ pub fn hann_in_place(window: &mut [f32]) {
     let size = window.len();
 
     // We want to scale `[0, size - 1]` to `[0, pi]`.
-    // XXX: The `sin^2()` version results in weird rounding errors that cause spectral leakeage
+    // XXX: The `sin^2()` version results in weird rounding errors that cause spectral leakage
     let scale = (size as f32 - 1.0).recip() * f32::consts::TAU;
     for (i, sample) in window.iter_mut().enumerate() {
         let cos = (i as f32 * scale).cos();

--- a/src/util/window.rs
+++ b/src/util/window.rs
@@ -1,4 +1,4 @@
-//! Windowing functions, useful in conjuction with [`StftHelper`][super::StftHelper].
+//! Windowing functions, useful in conjunction with [`StftHelper`][super::StftHelper].
 
 use std::f32;
 

--- a/src/wrapper/clap/factory.rs
+++ b/src/wrapper/clap/factory.rs
@@ -10,7 +10,7 @@ use super::descriptor::PluginDescriptor;
 use super::wrapper::Wrapper;
 use crate::plugin::ClapPlugin;
 
-/// The plugin's factory. Initialized using a lazy_static from the entry poiunt's `get_factory()`
+/// The plugin's factory. Initialized using a lazy_static from the entry point's `get_factory()`
 /// function. From this point onwards we don't need to generate code with macros anymore.
 #[doc(hidden)]
 #[repr(C)]

--- a/src/wrapper/clap/util.rs
+++ b/src/wrapper/clap/util.rs
@@ -14,7 +14,7 @@ macro_rules! check_null_ptr {
 /// The same as [`check_null_ptr!`], but with a custom message.
 macro_rules! check_null_ptr_msg {
     ($msg:expr, $ret:expr, $ptr:expr $(, $ptrs:expr)* $(, )?) => {
-        // Clippy doesn't understand it when we use a unit in our `check_null_ptr!()` maccro, even
+        // Clippy doesn't understand it when we use a unit in our `check_null_ptr!()` macro, even
         // if we explicitly pattern match on that unit
         #[allow(clippy::unused_unit)]
         if $ptr.is_null() $(|| $ptrs.is_null())* {

--- a/src/wrapper/clap/util.rs
+++ b/src/wrapper/clap/util.rs
@@ -28,7 +28,7 @@ macro_rules! check_null_ptr_msg {
 /// be null pointers, people will still use null pointers for some of the function arguments. This
 /// also happens in the official `clap-helpers`. As such, these functions are now `Option<fn(...)>`
 /// optional function pointers in `clap-sys`. This macro asserts that the pointer is not null, and
-/// prints a nicely formatted error message containing the struct and funciton name if it is. It
+/// prints a nicely formatted error message containing the struct and function name if it is. It
 /// also emulates C's syntax for accessing fields struct through a pointer. Except that it uses `=>`
 /// instead of `->`. Because that sounds like it would be hilarious.
 macro_rules! clap_call {

--- a/src/wrapper/clap/wrapper.rs
+++ b/src/wrapper/clap/wrapper.rs
@@ -203,7 +203,7 @@ pub struct Wrapper<P: ClapPlugin> {
 
     clap_plugin_params: clap_plugin_params,
     host_params: AtomicRefCell<Option<ClapPtr<clap_host_params>>>,
-    // These fiels are exactly the same as their VST3 wrapper counterparts.
+    // These fields are exactly the same as their VST3 wrapper counterparts.
     //
     /// The keys from `param_map` in a stable order.
     param_hashes: Vec<u32>,
@@ -338,7 +338,7 @@ impl<P: ClapPlugin> EventLoop<Task, Wrapper<P>> for Wrapper<P> {
                 unsafe_clap_call! { thread_check=>is_main_thread(&*self.host_callback) }
             }
             // FIXME: `thread::current()` may allocate the first time it's called, is there a safe
-            //        nonallocating version of this without using huge OS-specific libraries?
+            //        non-allocating version of this without using huge OS-specific libraries?
             None => permit_alloc(|| thread::current().id() == self.main_thread_id),
         }
     }
@@ -394,7 +394,7 @@ impl<P: ClapPlugin> Wrapper<P> {
         assert!(!host_callback.is_null());
         let host_callback = unsafe { ClapPtr::new(host_callback) };
 
-        // This is a mapping from the parameter IDs specified by the plugin to pointers to thsoe
+        // This is a mapping from the parameter IDs specified by the plugin to pointers to those
         // parameters. These pointers are assumed to be safe to dereference as long as
         // `wrapper.plugin` is alive. The plugin API identifiers these parameters by hashes, which
         // we'll calculate from the string ID specified by the plugin. These parameters should also
@@ -831,7 +831,7 @@ impl<P: ClapPlugin> Wrapper<P> {
         let mut input_events = self.input_events.borrow_mut();
         input_events.clear();
 
-        // To achive this, we'll always read one event ahead
+        // To achieve this, we'll always read one event ahead
         let num_events = clap_call! { in_=>size(in_) };
         if num_events == 0 {
             return None;
@@ -867,7 +867,7 @@ impl<P: ClapPlugin> Wrapper<P> {
         );
 
         // NOTE: We explicitly did not do this on a block split because that seems a bit excessive.
-        //       When we're performing a block split we're guarenteed that there's still at least one more
+        //       When we're performing a block split we're guaranteed that there's still at least one more
         //       parameter event after the split so this function will still be called.
         if parameter_values_changed {
             self.notify_param_values_changed();
@@ -1283,12 +1283,12 @@ impl<P: ClapPlugin> Wrapper<P> {
                 );
 
                 // If the parameter supports polyphonic modulation, then the plugin needs to be
-                // informed that the parmaeter has been monophonicall automated. This allows the
+                // informed that the parameter has been monophonically automated. This allows the
                 // plugin to update all of its polyphonic modulation values, since polyphonic
                 // modulation acts as an offset to the monophonic value.
                 if let Some(poly_modulation_id) = self.poly_mod_ids_by_hash.get(&event.param_id) {
                     // The modulation offset needs to be normalized to account for modulated
-                    // integer or enum parmaeters
+                    // integer or enum parameters
                     let param_ptr = self.param_by_hash[&event.param_id];
                     let normalized_value =
                         event.value as f32 / param_ptr.step_count().unwrap_or(1) as f32;
@@ -1309,7 +1309,7 @@ impl<P: ClapPlugin> Wrapper<P> {
                     match self.poly_mod_ids_by_hash.get(&event.param_id) {
                         Some(poly_modulation_id) => {
                             // The modulation offset needs to be normalized to account for modulated
-                            // integer or enum parmaeters
+                            // integer or enum parameters
                             let param_ptr = self.param_by_hash[&event.param_id];
                             let normalized_offset =
                                 event.amount as f32 / param_ptr.step_count().unwrap_or(1) as f32;
@@ -1652,7 +1652,7 @@ impl<P: ClapPlugin> Wrapper<P> {
         check_null_ptr!(false, plugin);
         let wrapper = &*(plugin as *const Self);
 
-        // We weren't allowed to query these in the constructor, so we need to do it now intead.
+        // We weren't allowed to query these in the constructor, so we need to do it now instead.
         *wrapper.host_gui.borrow_mut() =
             query_host_extension::<clap_host_gui>(&wrapper.host_callback, CLAP_EXT_GUI);
         *wrapper.host_latency.borrow_mut() =
@@ -1692,7 +1692,7 @@ impl<P: ClapPlugin> Wrapper<P> {
             process_mode: wrapper.current_process_mode.load(),
         };
 
-        // Befure initializing the plugin, make sure all smoothers are set the the default values
+        // Before initializing the plugin, make sure all smoothers are set the the default values
         for param in wrapper.param_by_hash.values() {
             param.update_smoother(buffer_config.sample_rate, true);
         }
@@ -1821,7 +1821,7 @@ impl<P: ClapPlugin> Wrapper<P> {
             let process = &*process;
 
             // Before doing anything, clear out any auxiliary outputs since they may contain
-            // uninitialized data when the host assumes that we'll always write soemthing there
+            // uninitialized data when the host assumes that we'll always write something there
             let current_bus_config = wrapper.current_bus_config.load();
             let has_main_input = current_bus_config.num_input_channels > 0;
             let has_main_output = current_bus_config.num_output_channels > 0;
@@ -1891,8 +1891,8 @@ impl<P: ClapPlugin> Wrapper<P> {
                     );
 
                     // If there are any parameter changes after `block_start` and sample
-                    // accurate automatoin is enabled or the host sends new transport
-                    // inforamtion, then we'll process a new block just after that. Otherwise we can
+                    // accurate automation is enabled or the host sends new transport
+                    // information, then we'll process a new block just after that. Otherwise we can
                     // process all audio until the end of the buffer.
                     match split_result {
                         Some((next_param_change_sample_idx, next_param_change_event_idx)) => {
@@ -2932,7 +2932,7 @@ impl<P: ClapPlugin> Wrapper<P> {
         strlcpy(&mut param_info.module, param_group);
         // We don't use the actual minimum and maximum values here because that would not scale
         // with skewed integer ranges. Instead, just treat all parameters as `[0, 1]` normalized
-        // paramters multiplied by the step size.
+        // parameters multiplied by the step size.
         param_info.min_value = 0.0;
         // Stepped parameters are unnormalized float parameters since there's no separate step
         // range option

--- a/src/wrapper/clap/wrapper.rs
+++ b/src/wrapper/clap/wrapper.rs
@@ -445,7 +445,7 @@ impl<P: ClapPlugin> Wrapper<P> {
                 param_map.len(),
                 param_ids.len(),
                 "The plugin has duplicate parameter IDs, weird things may happen. Consider using \
-                 6 character parameter IDs to avoid collissions."
+                 6 character parameter IDs to avoid collisions."
             );
 
             let poly_mod_ids: HashSet<u32> = poly_mod_ids_by_hash.values().copied().collect();
@@ -886,7 +886,7 @@ impl<P: ClapPlugin> Wrapper<P> {
         let sample_rate = self.current_buffer_config.load().map(|c| c.sample_rate);
         let mut parameter_values_changed = false;
         while let Some(change) = self.output_parameter_events.pop() {
-            let push_succesful = match change {
+            let push_successful = match change {
                 OutputParamEvent::BeginGesture { param_hash } => {
                     let event = clap_event_param_gesture {
                         header: clap_event_header {
@@ -947,7 +947,7 @@ impl<P: ClapPlugin> Wrapper<P> {
                 }
             };
 
-            nih_debug_assert!(push_succesful);
+            nih_debug_assert!(push_successful);
         }
 
         // Allow the editor to react to the new parameter values if the editor uses a reactive data

--- a/src/wrapper/clap/wrapper.rs
+++ b/src/wrapper/clap/wrapper.rs
@@ -143,10 +143,10 @@ pub struct Wrapper<P: ClapPlugin> {
     /// The last process status returned by the plugin. This is used for tail handling.
     last_process_status: AtomicCell<ProcessStatus>,
     /// The current latency in samples, as set by the plugin through the [`ProcessContext`]. uses
-    /// the latency extnesion
+    /// the latency extension
     pub current_latency: AtomicU32,
-    /// Contains slices for the plugin's outputs. You can't directly create a nested slice form
-    /// apointer to pointers, so this needs to be preallocated in the setup call and kept around
+    /// Contains slices for the plugin's outputs. You can't directly create a nested slice from
+    /// a pointer to pointers, so this needs to be preallocated in the setup call and kept around
     /// between process calls. This buffer owns the vector, because otherwise it would need to store
     /// a mutable reference to the data contained in this mutex.
     output_buffer: AtomicRefCell<Buffer<'static>>,
@@ -215,7 +215,7 @@ pub struct Wrapper<P: ClapPlugin> {
     /// by slashes, and they're only used to allow the DAW to display parameters in a tree
     /// structure.
     param_group_by_hash: HashMap<u32, String>,
-    /// Mappings from string parameter indentifiers to parameter hashes. Useful for debug logging
+    /// Mappings from string parameter identifiers to parameter hashes. Useful for debug logging
     /// and when storing and restoring plugin state.
     param_id_to_hash: HashMap<String, u32>,
     /// The inverse mapping from [`param_by_hash`][Self::param_by_hash]. This is needed to be able
@@ -230,7 +230,7 @@ pub struct Wrapper<P: ClapPlugin> {
     /// A queue of parameter changes and gestures that should be output in either the next process
     /// call or in the next parameter flush.
     ///
-    /// XXX: There's no guarentee that a single parameter doesn't occur twice in this queue, but
+    /// XXX: There's no guarantee that a single parameter doesn't occur twice in this queue, but
     ///      even if it does then that should still not be a problem because the host also reads it
     ///      in the same order, right?
     output_parameter_events: ArrayQueue<OutputParamEvent>,
@@ -690,7 +690,7 @@ impl<P: ClapPlugin> Wrapper<P> {
         }
     }
 
-    /// Queue a parmeter output event to be sent to the host at the end of the audio processing
+    /// Queue a parameter output event to be sent to the host at the end of the audio processing
     /// cycle, and request a parameter flush from the host if the plugin is not currently processing
     /// audio. The parameter's actual value will only be updated at that point so the value won't
     /// change in the middle of a processing call.
@@ -746,7 +746,7 @@ impl<P: ClapPlugin> Wrapper<P> {
     ///
     /// After calling this function, you should call
     /// [`notify_param_values_changed()`][Self::notify_param_values_changed()] to allow the editor
-    /// to update itself. This needs to be done seperately so you can process parameter changes in
+    /// to update itself. This needs to be done separately so you can process parameter changes in
     /// batches.
     ///
     /// # Note
@@ -812,13 +812,13 @@ impl<P: ClapPlugin> Wrapper<P> {
     }
 
     /// Similar to [`handle_in_events()`][Self::handle_in_events()], but will stop just before an
-    /// event if the preducate returns true for that events. This predicate is only called for
+    /// event if the predicate returns true for that events. This predicate is only called for
     /// events that occur after `current_sample_idx`. This is used to stop before a tempo or time
     /// signature change, or before next parameter change event with `raw_event.time >
     /// current_sample_idx` and return the **absolute** (relative to the entire buffer that's being
     /// split) sample index of that event along with the its index in the event queue as a
     /// `(sample_idx, event_idx)` tuple. This allows for splitting the audio buffer into segments
-    /// with distinct sample values to enable sample accurate automation without modifcations to the
+    /// with distinct sample values to enable sample accurate automation without modifications to the
     /// wrapped plugin.
     pub unsafe fn handle_in_events_until(
         &self,
@@ -3199,7 +3199,7 @@ impl<P: ClapPlugin> Wrapper<P> {
     }
 }
 
-/// Convenience function to query an extennsion from the host.
+/// Convenience function to query an extension from the host.
 ///
 /// # Safety
 ///

--- a/src/wrapper/standalone/backend/cpal.rs
+++ b/src/wrapper/standalone/backend/cpal.rs
@@ -342,7 +342,7 @@ impl Cpal {
 
         move |data, _info| {
             // Things may have been moved in between callbacks, so these pointers need to be set up
-            // agian on each invocation
+            // again on each invocation
             unsafe {
                 buffer.with_raw_vec(|output_slices| {
                     for (output_slice, channel) in output_slices.iter_mut().zip(channels.iter_mut())

--- a/src/wrapper/standalone/backend/jack.rs
+++ b/src/wrapper/standalone/backend/jack.rs
@@ -119,7 +119,7 @@ impl Backend for Jack {
                     // Unless it is a SysEx message, a JACK MIDI message is always three bytes or
                     // less and is normalized (starts with a status byte and is self-contained).
                     if midi.bytes.len() <= 3 {
-                        // JACK may not pad messages with zeroes, so mesages for things like channel
+                        // JACK may not pad messages with zeroes, so messages for things like channel
                         // pressure may be less than three bytes in length.
                         let mut midi_data = [0u8; 3];
                         midi_data[..midi.bytes.len()].copy_from_slice(midi.bytes);

--- a/src/wrapper/standalone/context.rs
+++ b/src/wrapper/standalone/context.rs
@@ -60,7 +60,7 @@ impl<P: Plugin, B: Backend> GuiContext for WrapperGuiContext<P, B> {
     }
 
     unsafe fn raw_begin_set_parameter(&self, _param: ParamPtr) {
-        // Since there's no autmoation being recorded here, gestures don't mean anything
+        // Since there's no automation being recorded here, gestures don't mean anything
     }
 
     unsafe fn raw_set_parameter_normalized(&self, param: ParamPtr, normalized: f32) {

--- a/src/wrapper/standalone/wrapper.rs
+++ b/src/wrapper/standalone/wrapper.rs
@@ -147,7 +147,7 @@ impl<P: Plugin, B: Backend> Wrapper<P, B> {
                 param_map.len(),
                 param_ids.len(),
                 "The plugin has duplicate parameter IDs, weird things may happen. Consider using \
-                 6 character parameter IDs to avoid collissions.."
+                 6 character parameter IDs to avoid collisions."
             );
 
             let mut bypass_param_exists = false;
@@ -325,13 +325,13 @@ impl<P: Plugin, B: Backend> Wrapper<P, B> {
             return false;
         }
 
-        let push_succesful = self
+        let push_successful = self
             .unprocessed_param_changes
             .push((param, normalized))
             .is_ok();
-        nih_debug_assert!(push_succesful, "The parameter change queue was full");
+        nih_debug_assert!(push_successful, "The parameter change queue was full");
 
-        push_succesful
+        push_successful
     }
 
     /// The DPI scale factor for this standalone application

--- a/src/wrapper/standalone/wrapper.rs
+++ b/src/wrapper/standalone/wrapper.rs
@@ -217,7 +217,7 @@ impl<P: Plugin, B: Backend> Wrapper<P, B> {
                 });
             }
 
-            // Befure initializing the plugin, make sure all smoothers are set the the default values
+            // Before initializing the plugin, make sure all smoothers are set the the default values
             for param in wrapper.known_parameters.iter() {
                 unsafe { param.update_smoother(wrapper.buffer_config.sample_rate, true) };
             }
@@ -388,7 +388,7 @@ impl<P: Plugin, B: Backend> Wrapper<P, B> {
             move |buffer, transport, input_events, output_events| {
                 // TODO: This process wrapper should actually be in the backends (since the backends
                 //       should also not allocate in their audio callbacks), but that's a bit more
-                //       erorr prone
+                //       error prone
                 process_wrapper(|| {
                     if should_terminate.load(Ordering::SeqCst) {
                         return false;

--- a/src/wrapper/standalone/wrapper.rs
+++ b/src/wrapper/standalone/wrapper.rs
@@ -318,7 +318,7 @@ impl<P: Plugin, B: Backend> Wrapper<P, B> {
     /// processing cycle, and this won't do anything if the parameter has not been registered by the
     /// plugin.
     ///
-    /// This returns false if the parmeter was not set because the `Paramptr` was either unknown or
+    /// This returns false if the parameter was not set because the `ParamPtr` was either unknown or
     /// the queue is full.
     pub fn set_parameter(&self, param: ParamPtr, normalized: f32) -> bool {
         if !self.known_parameters.contains(&param) {

--- a/src/wrapper/state.rs
+++ b/src/wrapper/state.rs
@@ -40,9 +40,9 @@ pub struct PluginState {
     #[serde(default)]
     pub version: String,
 
-    /// The plugin's parameter values. These are stored unnormalized. This mean sthe old values will
+    /// The plugin's parameter values. These are stored unnormalized. This means the old values will
     /// be recalled when when the parameter's range gets increased. Doing so may still mess with
-    /// parameter automation though, depending on how the host impelments that.
+    /// parameter automation though, depending on how the host implements that.
     pub params: BTreeMap<String, ParamValue>,
     /// Arbitrary fields that should be persisted together with the plugin's parameters. Any field
     /// on the [`Params`][crate::param::internals::Params] struct that's annotated with `#[persist =

--- a/src/wrapper/vst3/context.rs
+++ b/src/wrapper/vst3/context.rs
@@ -73,8 +73,8 @@ impl<P: Vst3Plugin> GuiContext for WrapperGuiContext<P> {
                     // changing in the middle of the process callback, which would be unsound.
                     // FIXME: So this doesn't work for REAPER, because they just silently stop
                     //        processing audio when you bypass the plugin. Great. We can add a time
-                    //        based heuristic to work aorund this in the meantime.
                     concat!("asfd", "dsaf", stringify!(34));
+                    //        based heuristic to work around this in the meantime.
                     if !self.inner.is_processing.load(Ordering::SeqCst) {
                         self.inner.set_normalized_value_by_hash(
                             *hash,

--- a/src/wrapper/vst3/context.rs
+++ b/src/wrapper/vst3/context.rs
@@ -73,7 +73,6 @@ impl<P: Vst3Plugin> GuiContext for WrapperGuiContext<P> {
                     // changing in the middle of the process callback, which would be unsound.
                     // FIXME: So this doesn't work for REAPER, because they just silently stop
                     //        processing audio when you bypass the plugin. Great. We can add a time
-                    concat!("asfd", "dsaf", stringify!(34));
                     //        based heuristic to work around this in the meantime.
                     if !self.inner.is_processing.load(Ordering::SeqCst) {
                         self.inner.set_normalized_value_by_hash(

--- a/src/wrapper/vst3/factory.rs
+++ b/src/wrapper/vst3/factory.rs
@@ -13,7 +13,7 @@ use super::wrapper::Wrapper;
 use crate::plugin::Vst3Plugin;
 use crate::wrapper::util::strlcpy;
 
-/// The VST3 SDK version this is roughtly based on. The bindings include some VST 3.7 things but not
+/// The VST3 SDK version this is roughly based on. The bindings include some VST 3.7 things but not
 /// everything, so we'll play it safe.
 const VST3_SDK_VERSION: &str = "VST 3.6.14";
 

--- a/src/wrapper/vst3/inner.rs
+++ b/src/wrapper/vst3/inner.rs
@@ -55,7 +55,7 @@ pub(crate) struct WrapperInner<P: Vst3Plugin> {
     /// This AtomicRefCell+Option is only needed because it has to be initialized late. There is no
     /// reason to mutably borrow the event loop, so reads will never be contested.
     ///
-    /// TODO: Is there a better type for Send+Sync late initializaiton?
+    /// TODO: Is there a better type for Send+Sync late initialization?
     pub event_loop: AtomicRefCell<Option<OsEventLoop<Task, Self>>>,
 
     /// Whether the plugin is currently processing audio. In other words, the last state
@@ -72,8 +72,8 @@ pub(crate) struct WrapperInner<P: Vst3Plugin> {
     pub last_process_status: AtomicCell<ProcessStatus>,
     /// The current latency in samples, as set by the plugin through the [`ProcessContext`].
     pub current_latency: AtomicU32,
-    /// Contains slices for the plugin's outputs. You can't directly create a nested slice form
-    /// apointer to pointers, so this needs to be preallocated in the setup call and kept around
+    /// Contains slices for the plugin's outputs. You can't directly create a nested slice from
+    /// a pointer to pointers, so this needs to be preallocated in the setup call and kept around
     /// between process calls. This buffer owns the vector, because otherwise it would need to store
     /// a mutable reference to the data contained in this mutex.
     pub output_buffer: AtomicRefCell<Buffer<'static>>,
@@ -102,7 +102,7 @@ pub(crate) struct WrapperInner<P: Vst3Plugin> {
     pub output_events: AtomicRefCell<VecDeque<NoteEvent>>,
     /// VST3 has several useful predefined note expressions, but for some reason they are the only
     /// note event type that don't have MIDI note ID and channel fields. So we need to keep track of
-    /// the msot recent VST3 note IDs we've seen, and then map those back to MIDI note IDs and
+    /// the most recent VST3 note IDs we've seen, and then map those back to MIDI note IDs and
     /// channels as needed.
     pub note_expression_controller: AtomicRefCell<NoteExpressionController>,
     /// Unprocessed parameter changes and note events sent by the host during a process call.
@@ -134,8 +134,8 @@ pub(crate) struct WrapperInner<P: Vst3Plugin> {
     /// `params` object does not get deallocated.
     pub param_by_hash: HashMap<u32, ParamPtr>,
     pub param_units: ParamUnits,
-    /// Mappings from string parameter indentifiers to parameter hashes. Useful for debug logging
-    /// and when storing and restorign plugin state.
+    /// Mappings from string parameter identifiers to parameter hashes. Useful for debug logging
+    /// and when storing and restoring plugin state.
     pub param_id_to_hash: HashMap<String, u32>,
     /// The inverse mapping from [`param_by_hash`][Self::param_by_hash]. This is needed to be able
     /// to have an ergonomic parameter setting API that uses references to the parameters instead of
@@ -153,7 +153,7 @@ pub enum Task {
     /// [`vst3_sys::vst::RestartFlags`].
     TriggerRestart(i32),
     /// Request the editor to be resized according to its current size. Right now there is no way to
-    /// handle denied resize requestsyet.
+    /// handle "denied resize" requests yet.
     RequestResize,
 }
 
@@ -384,7 +384,7 @@ impl<P: Vst3Plugin> WrapperInner<P> {
     ///
     /// After calling this function, you should call
     /// [`notify_param_values_changed()`][Self::notify_param_values_changed()] to allow the editor
-    /// to update itself. This needs to be done seperately so you can process parameter changes in
+    /// to update itself. This needs to be done separately so you can process parameter changes in
     /// batches.
     pub fn set_normalized_value_by_hash(
         &self,

--- a/src/wrapper/vst3/inner.rs
+++ b/src/wrapper/vst3/inner.rs
@@ -196,7 +196,7 @@ impl<P: Vst3Plugin> WrapperInner<P> {
         // on `Self::updated_state_sender`
         let (updated_state_sender, updated_state_receiver) = channel::bounded(0);
 
-        // This is a mapping from the parameter IDs specified by the plugin to pointers to thsoe
+        // This is a mapping from the parameter IDs specified by the plugin to pointers to those
         // parameters. These pointers are assumed to be safe to dereference as long as
         // `wrapper.plugin` is alive. The plugin API identifiers these parameters by hashes, which
         // we'll calculate from the string ID specified by the plugin. These parameters should also
@@ -357,7 +357,7 @@ impl<P: Vst3Plugin> WrapperInner<P> {
         } else {
             // If the editor is open, and the host exposes the `IRunLoop` interface, then we'll run
             // the task on the host's GUI thread using that interface. Otherwise we'll use the
-            // regular eent loop. If the editor gets dropped while there's still outstanding work
+            // regular event loop. If the editor gets dropped while there's still outstanding work
             // left in the run loop task queue, then those tasks will be posted to the regular event
             // loop so no work is lost.
             match &*self.plug_view.read() {
@@ -507,7 +507,7 @@ impl<P: Vst3Plugin> MainThreadExecutor<Task> for WrapperInner<P> {
         // TODO: When we add GUI resizing and context menus, this should propagate those events to
         //       `IRunLoop` on Linux to keep REAPER happy. That does mean a double spool, but we can
         //       come up with a nicer solution to handle that later (can always add a separate
-        //       function for checking if a to be scheduled task can be handled right ther and
+        //       function for checking if a to be scheduled task can be handled right there and
         //       then).
         match task {
             Task::TriggerRestart(flags) => match &*self.component_handler.borrow() {

--- a/src/wrapper/vst3/inner.rs
+++ b/src/wrapper/vst3/inner.rs
@@ -220,7 +220,7 @@ impl<P: Vst3Plugin> WrapperInner<P> {
                 param_map.len(),
                 param_ids.len(),
                 "The plugin has duplicate parameter IDs, weird things may happen. Consider using \
-                 6 character parameter IDs to avoid collissions.."
+                 6 character parameter IDs to avoid collisions."
             );
 
             let mut bypass_param_exists = false;

--- a/src/wrapper/vst3/note_expressions.rs
+++ b/src/wrapper/vst3/note_expressions.rs
@@ -26,7 +26,7 @@ pub const EXPRESSION_EXPRESSION_ID: u32 = 4;
 pub const BRIGHTNESS_EXPRESSION_ID: u32 = 5;
 
 /// The note expressions we support. It's completely undocumented, but apparently VST3 plugins need
-/// to specifically define a custom note expression for the predefined note expressiosn for them to
+/// to specifically define a custom note expression for the predefined note expressions for them to
 /// work.
 pub const KNOWN_NOTE_EXPRESSIONS: [NoteExpressionInfo; 6] = [
     NoteExpressionInfo {

--- a/src/wrapper/vst3/param_units.rs
+++ b/src/wrapper/vst3/param_units.rs
@@ -1,6 +1,6 @@
 //! Parameter hierarchies in VST3 requires you to define units, which are linearly indexed logical
 //! units that have a name, a parent, and then a whole bunch of other data like note numbers and
-//! MIDI program state. We'll need to implement some of that to conver our list of slash-separated
+//! MIDI program state. We'll need to implement some of that to convert our list of slash-separated
 //! parameter group paths to units.
 //!
 //! <https://steinbergmedia.github.io/vst3_doc/vstinterfaces/classSteinberg_1_1Vst_1_1IUnitInfo.html>
@@ -152,7 +152,7 @@ impl ParamUnits {
         Some((index as i32 + 1, info))
     }
 
-    /// Get the ID of the unit the paramter belongs to or. `kRootUnitId`/0 indicates the root unit.
+    /// Get the ID of the unit the parameter belongs to. `kRootUnitId`/0 indicates the root unit.
     pub fn get_vst3_unit_id(&self, param_hash: u32) -> Option<i32> {
         self.unit_id_by_hash.get(&param_hash).copied()
     }

--- a/src/wrapper/vst3/view.rs
+++ b/src/wrapper/vst3/view.rs
@@ -345,7 +345,7 @@ impl<P: Vst3Plugin> IPlugView for WrapperView<P> {
     }
 
     unsafe fn on_wheel(&self, _distance: f32) -> tresult {
-        // We'll let the plugin use the OS' input mechamisms because not all DAWs (or very few
+        // We'll let the plugin use the OS' input mechanisms because not all DAWs (or very few
         // actually) implement these functions
         kResultOk
     }
@@ -504,7 +504,7 @@ impl<P: Vst3Plugin> IEventHandler for RunLoopEventHandler<P> {
 #[cfg(target_os = "linux")]
 impl<P: Vst3Plugin> Drop for RunLoopEventHandler<P> {
     fn drop(&mut self) {
-        // When this object gets dropped and there are still unprocssed tasks left, then we'll
+        // When this object gets dropped and there are still unprocessed tasks left, then we'll
         // handle those in the regular event loop so no work gets lost
         let mut posting_failed = false;
         while let Some(task) = self.tasks.pop() {
@@ -519,7 +519,7 @@ impl<P: Vst3Plugin> Drop for RunLoopEventHandler<P> {
 
         if posting_failed {
             nih_debug_assert_failure!(
-                "Outstanding tasks have been dropped when clsoing the editor as the task queue \
+                "Outstanding tasks have been dropped when closing the editor as the task queue \
                  was full"
             );
         }

--- a/src/wrapper/vst3/view.rs
+++ b/src/wrapper/vst3/view.rs
@@ -80,7 +80,7 @@ struct RunLoopEventHandler<P: Vst3Plugin> {
     /// this object gets dropped so no work is lost.
     inner: Arc<WrapperInner<P>>,
 
-    /// The host's run lopp interface. This lets us run tasks on the same thread as the host's UI.
+    /// The host's run loop interface. This lets us run tasks on the same thread as the host's UI.
     run_loop: VstPtr<dyn IRunLoop>,
 
     /// We need a Unix domain socket the host can poll to know that we have an event to handle. In

--- a/src/wrapper/vst3/wrapper.rs
+++ b/src/wrapper/vst3/wrapper.rs
@@ -73,7 +73,7 @@ impl<P: Vst3Plugin> IPluginBase for Wrapper<P> {
 
 impl<P: Vst3Plugin> IComponent for Wrapper<P> {
     unsafe fn get_controller_class_id(&self, _tuid: *mut vst3_sys::IID) -> tresult {
-        // We won't separate the edit controller to keep the implemetnation a bit smaller
+        // We won't separate the edit controller to keep the implementation a bit smaller
         kNoInterface
     }
 
@@ -383,7 +383,7 @@ impl<P: Vst3Plugin> IComponent for Wrapper<P> {
         // custom channel layout overrides we need to initialize here.
         match (state != 0, self.inner.current_buffer_config.load()) {
             (true, Some(buffer_config)) => {
-                // Befure initializing the plugin, make sure all smoothers are set the the default values
+                // Before initializing the plugin, make sure all smoothers are set the the default values
                 for param in self.inner.param_by_hash.values() {
                     param.update_smoother(buffer_config.sample_rate, true);
                 }
@@ -1033,7 +1033,7 @@ impl<P: Vst3Plugin> IAudioProcessor for Wrapper<P> {
             nih_debug_assert!(data.num_samples >= 0);
 
             // Before doing anything, clear out any auxiliary outputs since they may contain
-            // uninitialized data when the host assumes that we'll always write soemthing there
+            // uninitialized data when the host assumes that we'll always write something there
             let current_bus_config = self.inner.current_bus_config.load();
             let has_main_input = current_bus_config.num_input_channels > 0;
             // HACK: Bitwig requires VST3 plugins to always have a main output. We'll however still
@@ -1238,7 +1238,7 @@ impl<P: Vst3Plugin> IAudioProcessor for Wrapper<P> {
             // NOTE: It's important that this sort is stable, because parameter changes need to be
             //       processed before note events. Otherwise you'll get out of bounds note events
             //       with block splitting when the note event occurs at one index after the end (or
-            //       on the exlusive end index) of the block.
+            //       on the exclusive end index) of the block.
             process_events.sort_by_key(|event| match event {
                 ProcessEvent::ParameterChange { timing, .. } => *timing,
                 ProcessEvent::NoteEvent { timing, .. } => *timing,
@@ -1252,7 +1252,7 @@ impl<P: Vst3Plugin> IAudioProcessor for Wrapper<P> {
                 // sorted process event array until we run into for the current sample, and then
                 // process the block between the current sample and the sample containing the next
                 // parameter change, if any. All timings also need to be compensated for this. As
-                // mentioend above, for this to work correctly parameter changes need to be ordered
+                // mentioned above, for this to work correctly parameter changes need to be ordered
                 // before note events at the same index.
                 // The extra scope is here to make sure we release the borrow on input_events
                 {
@@ -1557,7 +1557,7 @@ impl<P: Vst3Plugin> IAudioProcessor for Wrapper<P> {
                         // There's also a ppqPos field, but uh how about no
                         vst3_event.sample_offset = event.timing() as i32 + block_start as i32;
 
-                        // `voice_id.onwrap_or(|| ...)` triggers
+                        // `voice_id.unwrap_or(|| ...)` triggers
                         // https://github.com/rust-lang/rust-clippy/issues/8522
                         #[allow(clippy::unnecessary_lazy_evaluations)]
                         match event {


### PR DESCRIPTION
While reading through `nih_plug`s documentation, I noticed some typos so I fixed them 😊
And since I was at it, I did some related work (each in a separate commit):
- Fix typos in comments
- Fix typos in test names
- Fix typos in productive code
- Remove a line of dead code (at least, as far as I see)
