### PR TITLE
Preserve the order of non-grouped nested parameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2640,6 +2640,7 @@ source = "git+https://github.com/robbert-vdh/nih_plug_assets.git#a04e327923e120b
 name = "nih_plug_derive"
 version = "0.1.0"
 dependencies = [
+ "nih_plug",
  "quote",
  "syn",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2641,6 +2641,7 @@ name = "nih_plug_derive"
 version = "0.1.0"
 dependencies = [
  "nih_plug",
+ "proc-macro2",
  "quote",
  "syn",
 ]

--- a/nih_plug_derive/Cargo.toml
+++ b/nih_plug_derive/Cargo.toml
@@ -11,3 +11,6 @@ proc-macro = true
 [dependencies]
 syn = { version = "1.0", features = ["extra-traits"] }
 quote = "1.0"
+
+[dev-dependencies]
+nih_plug = { path = ".." }

--- a/nih_plug_derive/Cargo.toml
+++ b/nih_plug_derive/Cargo.toml
@@ -11,6 +11,7 @@ proc-macro = true
 [dependencies]
 syn = { version = "1.0", features = ["extra-traits"] }
 quote = "1.0"
+proc-macro2 = "1.0"
 
 [dev-dependencies]
 nih_plug = { path = ".." }

--- a/nih_plug_derive/tests/params.rs
+++ b/nih_plug_derive/tests/params.rs
@@ -106,11 +106,12 @@ mod param_order {
     fn nested() {
         let p = NestedParams::default();
 
-        // Parameters must have the same order as they are defined in. Nested parameters are put in the end though.
+        // Parameters must have the same order as they are defined in. The position of nested parameters which are not
+        // grouped explicitly is preserved.
         let param_ids: Vec<String> = p.param_map().into_iter().map(|(id, _, _)| id).collect();
         assert_eq!(
             param_ids,
-            ["one", "three", "two_one", "two_two", "two_three"]
+            ["one", "two_one", "two_two", "two_three", "three",]
         );
     }
 }

--- a/nih_plug_derive/tests/params.rs
+++ b/nih_plug_derive/tests/params.rs
@@ -1,0 +1,116 @@
+use nih_plug::prelude::*;
+
+#[derive(Params)]
+struct FlatParams {
+    #[id = "one"]
+    pub one: BoolParam,
+
+    #[id = "two"]
+    pub two: FloatParam,
+
+    #[id = "three"]
+    pub three: IntParam,
+}
+
+impl Default for FlatParams {
+    fn default() -> Self {
+        FlatParams {
+            one: BoolParam::new("one", true),
+            two: FloatParam::new("two", 0.0, FloatRange::Linear { min: 0.0, max: 1.0 }),
+            three: IntParam::new("three", 0, IntRange::Linear { min: 0, max: 100 }),
+        }
+    }
+}
+
+#[derive(Params)]
+struct GroupedParams {
+    #[id = "one"]
+    pub one: BoolParam,
+
+    #[nested(group = "Some Group", id_prefix = "group1")]
+    pub group1: FlatParams,
+
+    #[id = "three"]
+    pub three: IntParam,
+
+    #[nested(group = "Another Group", id_prefix = "group2")]
+    pub group2: FlatParams,
+}
+
+impl Default for GroupedParams {
+    fn default() -> Self {
+        GroupedParams {
+            one: BoolParam::new("one", true),
+            group1: FlatParams::default(),
+            three: IntParam::new("three", 0, IntRange::Linear { min: 0, max: 100 }),
+            group2: FlatParams::default(),
+        }
+    }
+}
+
+#[derive(Params)]
+struct NestedParams {
+    #[id = "one"]
+    pub one: BoolParam,
+
+    #[nested(id_prefix = "two")]
+    pub two: FlatParams,
+
+    #[id = "three"]
+    pub three: IntParam,
+}
+
+impl Default for NestedParams {
+    fn default() -> Self {
+        NestedParams {
+            one: BoolParam::new("one", true),
+            two: FlatParams::default(),
+            three: IntParam::new("three", 0, IntRange::Linear { min: 0, max: 100 }),
+        }
+    }
+}
+
+mod param_order {
+    use super::*;
+    #[test]
+    fn flat() {
+        let p = FlatParams::default();
+
+        // Parameters must have the same order as they are defined in
+        let param_ids: Vec<String> = p.param_map().into_iter().map(|(id, _, _)| id).collect();
+        assert_eq!(param_ids, ["one", "two", "three",]);
+    }
+
+    #[test]
+    fn grouped() {
+        let p = GroupedParams::default();
+
+        // Parameters must have the same order as they are defined in. Groups are put in the end though.
+        let param_ids: Vec<String> = p.param_map().into_iter().map(|(id, _, _)| id).collect();
+        assert_eq!(
+            param_ids,
+            [
+                "one",
+                "three",
+                "group1_one",
+                "group1_two",
+                "group1_three",
+                "group2_one",
+                "group2_two",
+                "group2_three",
+            ]
+        );
+    }
+
+    #[test]
+    fn nested() {
+        let p = NestedParams::default();
+
+        // Parameters must have the same order as they are defined in. Nested parameters are put in the end though.
+        let param_ids: Vec<String> = p.param_map().into_iter().map(|(id, _, _)| id).collect();
+        assert_eq!(
+            param_ids,
+            ["one", "three", "two_one", "two_two", "two_three"]
+        );
+    }
+}


### PR DESCRIPTION
This resolves issue #43. Nested parameters that are **not grouped** are now inserted to the parameter list according to definition order. Grouped parameters remain at the bottom of the parameter list.