### PR TITLE
STFT: padding changes/fixes

### DIFF
--- a/src/util/stft.rs
+++ b/src/util/stft.rs
@@ -452,7 +452,7 @@ impl<const NUM_SIDECHAIN_INPUTS: usize> StftHelper<NUM_SIDECHAIN_INPUTS> {
                     // longer than the block size, then this will cause everything else to be
                     // shifted to the left so it can be added in the iteration after this.
                     if self.padding > 0 {
-                        let padding_to_copy = cmp::min(self.padding, block_size);
+                        let padding_to_copy = cmp::max(self.padding, block_size);
                         for (scratch_sample, padding_sample) in self.scratch_buffer
                             [..padding_to_copy]
                             .iter_mut()
@@ -463,7 +463,7 @@ impl<const NUM_SIDECHAIN_INPUTS: usize> StftHelper<NUM_SIDECHAIN_INPUTS> {
 
                         let remaining_padding = padding_to_copy - self.padding;
                         if remaining_padding > 0 {
-                            padding_buffer.copy_within(..padding_to_copy, 0);
+                            padding_buffer.copy_within(..self.padding, 0);
                         }
 
                         // And we obviously don't want this to feedback

--- a/src/util/stft.rs
+++ b/src/util/stft.rs
@@ -447,10 +447,10 @@ impl<const NUM_SIDECHAIN_INPUTS: usize> StftHelper<NUM_SIDECHAIN_INPUTS> {
                 // start with copying the wrapped ranges from our ring buffers to the scratch
                 // buffer. Then we apply the windowing function and this it along to
                 for (sidechain_idx, sidechain_ring_buffers) in
-                    self.sidechain_ring_buffers.iter().enumerate()
+                self.sidechain_ring_buffers.iter().enumerate()
                 {
                     for (channel_idx, sidechain_ring_buffer) in
-                        sidechain_ring_buffers.iter().enumerate()
+                    sidechain_ring_buffers.iter().enumerate()
                     {
                         copy_ring_to_scratch_buffer(
                             &mut self.scratch_buffer,
@@ -580,7 +580,7 @@ impl<const NUM_SIDECHAIN_INPUTS: usize> StftHelper<NUM_SIDECHAIN_INPUTS> {
 
             if samples_to_process == samples_until_next_window {
                 for (channel_idx, input_ring_buffer) in
-                    self.main_input_ring_buffers.iter().enumerate()
+                self.main_input_ring_buffers.iter().enumerate()
                 {
                     copy_ring_to_scratch_buffer(
                         &mut self.scratch_buffer,

--- a/src/util/stft.rs
+++ b/src/util/stft.rs
@@ -58,6 +58,7 @@ pub struct StftHelper<const NUM_SIDECHAIN_INPUTS: usize = 0> {
 }
 
 /// Marker struct for the version without sidechaining.
+#[derive(Clone, Copy)]
 struct NoSidechain;
 
 impl StftInput for Buffer<'_> {


### PR DESCRIPTION
the highlights:
- fixed an issue which causes a panic if padding is larger than block size
- included a way to change padding after initializing the helper. this behaves the same way as `set_block_size`