### PR TITLE
Consider switching to easyfft

### DIFF
--- a/plugins/crossover/Cargo.toml
+++ b/plugins/crossover/Cargo.toml
@@ -16,5 +16,6 @@ default = ["simd"]
 simd = ["nih_plug/simd"]
 
 [dependencies]
+easyfft = "0.3.5"
 nih_plug = { path = "../../", features = ["assert_process_allocs"] }
 realfft = "3.0.0"


### PR DESCRIPTION
[easyfftt](https://docs.rs/easyfft/latest/easyfft/) makes the logic simpler and gets rid of the planner struct.

If you're good with the idea, I'd be happy to convert the rest of the plugin examples.

Please let me know what you think.