### PR TITLE
Add a channel getter to the NoteEvent implementation

### DIFF
--- a/src/midi.rs
+++ b/src/midi.rs
@@ -386,6 +386,30 @@ impl<S> NoteEvent<S> {
             NoteEvent::MidiSysEx { .. } => None,
         }
     }
+
+    /// Returns the event's channel, if it has any.
+    pub fn channel(&self) -> Option<u8> {
+        match self {
+            NoteEvent::NoteOn { channel, .. } => Some(*channel),
+            NoteEvent::NoteOff { channel, .. } => Some(*channel),
+            NoteEvent::Choke { channel, .. } => Some(*channel),
+            NoteEvent::VoiceTerminated { channel, .. } => Some(*channel),
+            NoteEvent::PolyModulation { .. } => None,
+            NoteEvent::MonoAutomation { .. } => None,
+            NoteEvent::PolyPressure { channel, .. } => Some(*channel),
+            NoteEvent::PolyVolume { channel, .. } => Some(*channel),
+            NoteEvent::PolyPan { channel, .. } => Some(*channel),
+            NoteEvent::PolyTuning { channel, .. } => Some(*channel),
+            NoteEvent::PolyVibrato { channel, .. } => Some(*channel),
+            NoteEvent::PolyExpression { channel, .. } => Some(*channel),
+            NoteEvent::PolyBrightness { channel, .. } => Some(*channel),
+            NoteEvent::MidiChannelPressure { channel, .. } => Some(*channel),
+            NoteEvent::MidiPitchBend { channel, .. } => Some(*channel),
+            NoteEvent::MidiCC { channel, .. } => Some(*channel),
+            NoteEvent::MidiProgramChange { channel, .. } => Some(*channel),
+            NoteEvent::MidiSysEx { .. } => None,
+        }
+    }
 }
 
 impl<S: SysExMessage> NoteEvent<S> {


### PR DESCRIPTION
I noticed that I couln't read the channel of a NoteEvent without matching all the enum values, and thought it might be useful since there are already helpers for timing and voice_id (and well, I needed it :)).

I didn't find any contribution guideline, let me know if it's not the right way to do it.

Cheers!