### PR TITLE
Various MIRI fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,9 +180,9 @@ checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 
 [[package]]
 name = "anymap"
-version = "0.12.1"
+version = "1.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33954243bd79057c2de7338850b85983a44588021f8a5fee574a8888c6de4344"
+checksum = "8f1f8f5a6f3d50d89e3797d7593a50f96bb2aaa20ca0cc7be1fb673232c91d72"
 
 [[package]]
 name = "approx"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ docs = []
 nih_plug_derive = { path = "nih_plug_derive" }
 
 anyhow = "1.0"
-anymap = "0.12.1"
+anymap = "1.0.0-beta.2"
 atomic_float = "0.1"
 atomic_refcell = "0.1"
 backtrace = "0.3.65"

--- a/src/event_loop/background_thread.rs
+++ b/src/event_loop/background_thread.rs
@@ -77,7 +77,7 @@ where
 // workaround to have a singleton that also works if for whatever reason there arem ultiple `T`
 // and `E`s in a single process (won't happen with normal plugin usage, but sho knwos).
 lazy_static::lazy_static! {
-    static ref HANDLE_MAP: Mutex<anymap::Map<dyn anymap::any::Any + Send + 'static>> =
+    static ref HANDLE_MAP: Mutex<anymap::Map<dyn std::any::Any + Send + 'static>> =
         Mutex::new(anymap::Map::new());
 }
 

--- a/src/wrapper/clap.rs
+++ b/src/wrapper/clap.rs
@@ -44,7 +44,7 @@ macro_rules! nih_export_clap {
                     && unsafe { ::std::ffi::CStr::from_ptr(factory_id) }
                         == ::nih_plug::wrapper::clap::CLAP_PLUGIN_FACTORY_ID
                 {
-                    &(*FACTORY).clap_plugin_factory as *const _ as *const ::std::ffi::c_void
+                    &*FACTORY as *const _ as *const ::std::ffi::c_void
                 } else {
                     std::ptr::null()
                 }

--- a/src/wrapper/util.rs
+++ b/src/wrapper/util.rs
@@ -243,6 +243,7 @@ impl ScopedFtz {
             }
         }
 
+        #[allow(unreachable_code)] // This is only unreachable if on SSE or aarch64
         Self {
             should_disable_again: false,
             _send_sync_marker: PhantomData,


### PR DESCRIPTION
This PR fixes some a few issues MIRI reported when I ran the example `gain` plugin in Clack's host test suite:

* Update the `anymap` dependency: the `0.12.x` version on crates.io is unsound and performs unaligned writes, which are triggered in NIH-plug's CLAP wrapper when initializing the background thread. This PR updates it to the latest beta which doesn't use `unsafe` anymore.
* Fix the `get_factory` method only returning borrowing the inner `clap_plugin_factory` instead of the whole factory struct, which caused untagged access errors.
* Disable FTZ when running under MIRI. This isn't an error, just an unsupported operation in MIRI.