### PR TITLE
Added explicit module path in nih_export_clap.

### DIFF
--- a/src/wrapper/clap.rs
+++ b/src/wrapper/clap.rs
@@ -102,7 +102,7 @@ macro_rules! nih_export_clap {
                         // Arc does not have a convenient leak function like Box, so this gets a bit awkward
                         // This pointer gets turned into an Arc and its reference count decremented in
                         // [Wrapper::destroy()]
-                        return (*Arc::into_raw(::nih_plug::wrapper::clap::Wrapper::<$plugin_ty>::new(host)))
+                        return (*::std::sync::Arc::into_raw(::nih_plug::wrapper::clap::Wrapper::<$plugin_ty>::new(host)))
                             .clap_plugin
                             .as_ptr();
                     }


### PR DESCRIPTION
The macro definition of `nih_export_clap` is missing an explicit module path for `std::sync::Arc` which causes a compilation failure if the invocation site doesn't have `std::sync::Arc` in scope.