### PR TITLE
Fix backticks in doc comments

### DIFF
--- a/src/formatters.rs
+++ b/src/formatters.rs
@@ -78,7 +78,7 @@ pub fn s2v_compression_ratio() -> Arc<dyn Fn(&str) -> Option<f32> + Send + Sync>
 }
 
 /// Turn an `f32` value from voltage gain to decibels using the semantics described in
-/// [`util::gain_to_db()]. You should use either `" dB"` or `" dBFS"` for the parameter's unit.
+/// [`util::gain_to_db()`]. You should use either `" dB"` or `" dBFS"` for the parameter's unit.
 /// `0.0` will be formatted as `-inf`. Avoids returning negative zero values to make sure
 /// string->value->string roundtrips work correctly. Otherwise `-0.001` rounded to two digits
 /// would result in `-0.00`.
@@ -125,7 +125,7 @@ pub fn v2s_f32_panning() -> Arc<dyn Fn(f32) -> String + Send + Sync> {
     })
 }
 
-/// Parse a pan value in the format of [`v2s_f32_panning()] to a linear value in the range `[-1,
+/// Parse a pan value in the format of [`v2s_f32_panning()`] to a linear value in the range `[-1,
 /// 1]`.
 pub fn s2v_f32_panning() -> Arc<dyn Fn(&str) -> Option<f32> + Send + Sync> {
     Arc::new(|string| {
@@ -196,7 +196,7 @@ pub fn v2s_f32_hz_then_khz_with_note_name(
     })
 }
 
-/// Convert an input in the same format at that of [`v2s_f32_hz_then_khz()] to a Hertz value. This
+/// Convert an input in the same format at that of [`v2s_f32_hz_then_khz()`] to a Hertz value. This
 /// additionally also accepts note names in the same format as [`s2v_i32_note_formatter()`], and
 /// optionally also with cents in the form of `D#5, -23 ct.`.
 pub fn s2v_f32_hz_then_khz() -> Arc<dyn Fn(&str) -> Option<f32> + Send + Sync> {
@@ -277,7 +277,7 @@ pub fn v2s_i32_note_formatter() -> Arc<dyn Fn(i32) -> String + Send + Sync> {
     })
 }
 
-/// Parse a note name to a MIDI number using the inverse mapping from [`v2s_i32_note_formatter()].
+/// Parse a note name to a MIDI number using the inverse mapping from [`v2s_i32_note_formatter()`].
 pub fn s2v_i32_note_formatter() -> Arc<dyn Fn(&str) -> Option<i32> + Send + Sync> {
     Arc::new(|string| {
         let string = string.trim();
@@ -322,7 +322,7 @@ pub fn v2s_bool_bypass() -> Arc<dyn Fn(bool) -> String + Send + Sync> {
     })
 }
 
-/// Parse a string in the same format as [`v2s_bool_bypass()].
+/// Parse a string in the same format as [`v2s_bool_bypass()`].
 pub fn s2v_bool_bypass() -> Arc<dyn Fn(&str) -> Option<bool> + Send + Sync> {
     Arc::new(|string| {
         let string = string.trim();

--- a/src/midi.rs
+++ b/src/midi.rs
@@ -11,7 +11,7 @@ pub use midi_consts::channel_event::control_change;
 
 /// A plugin-specific note event type.
 ///
-/// The reason why this is defined like this instead of parameterizing `NoteEvent` with `P`` is
+/// The reason why this is defined like this instead of parameterizing `NoteEvent` with `P` is
 /// because deriving trait bounds requires all of the plugin's generic parameters to implement those
 /// traits. And we can't require `P` to implement things like `Clone`.
 ///

--- a/src/params.rs
+++ b/src/params.rs
@@ -177,7 +177,7 @@ pub trait Param: Display + Debug + sealed::Sealed {
 
     /// Get the plain, unnormalized value for this parameter after polyphonic modulation has been
     /// applied. This is a convenience method for calling [`preview_plain()`][Self::preview_plain()]
-    /// with `unmodulated_normalized_value() + normalized_offset`.`
+    /// with `unmodulated_normalized_value() + normalized_offset`.
     #[inline]
     fn preview_modulated(&self, normalized_offset: f32) -> Self::Plain {
         self.preview_plain(self.unmodulated_normalized_value() + normalized_offset)

--- a/src/params/float.rs
+++ b/src/params/float.rs
@@ -357,7 +357,7 @@ impl FloatParam {
         self
     }
 
-    /// Set the distance between steps of a [FloatParam]. Mostly useful for quantizing GUI input. If
+    /// Set the distance between steps of a [`FloatParam`]. Mostly useful for quantizing GUI input. If
     /// this is set and a [`value_to_string`][Self::with_value_to_string()] function is not set,
     /// then this is also used when formatting the parameter. This must be a positive, nonzero
     /// number.

--- a/src/params/smoothing.rs
+++ b/src/params/smoothing.rs
@@ -661,7 +661,7 @@ mod tests {
         assert_eq!(smoother.next(), 20);
     }
 
-    /// Same as [linear_f32_smoothing], but skipping steps instead.
+    /// Same as [`linear_f32_smoothing`], but skipping steps instead.
     #[test]
     fn skipping_linear_f32_smoothing() {
         let smoother: Smoother<f32> = Smoother::new(SmoothingStyle::Linear(100.0));
@@ -674,7 +674,7 @@ mod tests {
         assert_eq!(smoother.next(), 20.0);
     }
 
-    /// Same as [linear_i32_smoothing], but skipping steps instead.
+    /// Same as [`linear_i32_smoothing`], but skipping steps instead.
     #[test]
     fn skipping_linear_i32_smoothing() {
         let smoother: Smoother<i32> = Smoother::new(SmoothingStyle::Linear(100.0));
@@ -687,7 +687,7 @@ mod tests {
         assert_eq!(smoother.next(), 20);
     }
 
-    /// Same as [logarithmic_f32_smoothing], but skipping steps instead.
+    /// Same as [`logarithmic_f32_smoothing`], but skipping steps instead.
     #[test]
     fn skipping_logarithmic_f32_smoothing() {
         let smoother: Smoother<f32> = Smoother::new(SmoothingStyle::Logarithmic(100.0));
@@ -700,7 +700,7 @@ mod tests {
         assert_eq!(smoother.next(), 20.0);
     }
 
-    /// Same as [logarithmic_i32_smoothing], but skipping steps instead.
+    /// Same as [`logarithmic_i32_smoothing`], but skipping steps instead.
     #[test]
     fn skipping_logarithmic_i32_smoothing() {
         let smoother: Smoother<i32> = Smoother::new(SmoothingStyle::Logarithmic(100.0));

--- a/src/wrapper/clap/context.rs
+++ b/src/wrapper/clap/context.rs
@@ -37,7 +37,7 @@ pub(crate) struct PendingInitContextRequests {
 
 /// A [`ProcessContext`] implementation for the wrapper. This is a separate object so it can hold on
 /// to lock guards for event queues. Otherwise reading these events would require constant
-/// unnecessary atomic operations to lock the uncontested RwLocks.
+/// unnecessary atomic operations to lock the uncontested `RwLock`s.
 pub(crate) struct WrapperProcessContext<'a, P: ClapPlugin> {
     pub(super) wrapper: &'a Wrapper<P>,
     pub(super) input_events_guard: AtomicRefMut<'a, VecDeque<PluginNoteEvent<P>>>,

--- a/src/wrapper/clap/descriptor.rs
+++ b/src/wrapper/clap/descriptor.rs
@@ -9,7 +9,7 @@ use crate::prelude::ClapPlugin;
 /// itself.
 ///
 /// This cannot be cloned as [`Self::clap_features_ptrs`] contains pointers to
-/// [Self::clap_features].
+/// [`Self::clap_features`].
 pub struct PluginDescriptor {
     // We need [CString]s for all of `ClapPlugin`'s `&str` fields
     clap_id: CString,

--- a/src/wrapper/standalone/context.rs
+++ b/src/wrapper/standalone/context.rs
@@ -14,7 +14,7 @@ pub(crate) struct WrapperInitContext<'a, P: Plugin, B: Backend<P>> {
 
 /// A [`ProcessContext`] implementation for the standalone wrapper. This is a separate object so it
 /// can hold on to lock guards for event queues. Otherwise reading these events would require
-/// constant unnecessary atomic operations to lock the uncontested RwLocks.
+/// constant unnecessary atomic operations to lock the uncontested `RwLock`s.
 pub(crate) struct WrapperProcessContext<'a, P: Plugin, B: Backend<P>> {
     #[allow(dead_code)]
     pub(super) wrapper: &'a Wrapper<P, B>,

--- a/src/wrapper/state.rs
+++ b/src/wrapper/state.rs
@@ -1,4 +1,4 @@
-//! Utilities for saving a [crate::plugin::Plugin]'s state. The actual state object is also exposed
+//! Utilities for saving a [`crate::plugin::Plugin`]'s state. The actual state object is also exposed
 //! to plugins through the [`GuiContext`][crate::prelude::GuiContext].
 
 use anyhow::{Context, Result};

--- a/src/wrapper/vst3/util.rs
+++ b/src/wrapper/vst3/util.rs
@@ -65,7 +65,7 @@ pub struct VstPtr<T: vst3_sys::ComInterface + ?Sized> {
     ptr: vst3_sys::VstPtr<T>,
 }
 
-/// The same as [`VstPtr`] with shared semnatics, but for objects we defined ourself since VstPtr
+/// The same as [`VstPtr`] with shared semnatics, but for objects we defined ourself since `VstPtr`
 /// only works for interfaces.
 #[repr(transparent)]
 pub struct ObjectPtr<T: IUnknown> {

--- a/src/wrapper/vst3/view.rs
+++ b/src/wrapper/vst3/view.rs
@@ -114,7 +114,7 @@ impl<P: Vst3Plugin> WrapperView<P> {
         )
     }
 
-    /// Ask the host to resize the view to the size specified by [Editor::size()]. Will return false
+    /// Ask the host to resize the view to the size specified by [`Editor::size()`]. Will return false
     /// if the host doesn't like you. This **needs** to be run from the GUI thread.
     ///
     /// # Safety


### PR DESCRIPTION
Hello!

Courtesy of `clippy::doc_markdown`, here is a collection of what I hope are fairly uncontroversial tweaks to the docs: adding/removing backticks for visual consistency. 😅 

I left all mentions of `SysEx` alone because I see that they are consistently unticked and it's more of a concept than an explicit keyword (currently just an example plugin's name), but I could add those too if that's desired?