### PR TITLE
Added IntParam::range() and FloatParam::range()

### DIFF
--- a/src/params/float.rs
+++ b/src/params/float.rs
@@ -300,6 +300,12 @@ impl FloatParam {
         self.modulated_plain_value()
     }
 
+    /// The range of valid plain values for this parameter.
+    #[inline]
+    pub fn range(&self) -> FloatRange {
+        self.range
+    }
+
     /// Enable polyphonic modulation for this parameter. The ID is used to uniquely identify this
     /// parameter in [`NoteEvent::PolyModulation`][crate::prelude::NoteEvent::PolyModulation]
     /// events, and must thus be unique between _all_ polyphonically modulatable parameters. See the

--- a/src/params/integer.rs
+++ b/src/params/integer.rs
@@ -278,6 +278,12 @@ impl IntParam {
     pub fn value(&self) -> i32 {
         self.modulated_plain_value()
     }
+   
+    /// The range of valid plain values for this parameter.
+    #[inline]
+    pub fn range(&self) -> IntRange {
+        self.range
+    }
 
     /// Enable polyphonic modulation for this parameter. The ID is used to uniquely identify this
     /// parameter in [`NoteEvent::PolyModulation`][crate::prelude::NoteEvent::PolyModulation]


### PR DESCRIPTION
This allows calling code e.g. pass a bunch of IntParams to a function that creates widgets - removing the need to create custom widgets for each GUI library and instead use some glue code to generate widgets since now they can determine the correct bounds for a knob/slider from the &IntParam

I'm open to modifying it to return &Range instead of Range... over to you on that API decision
