### PR TITLE
Fix an error in nih_export_vst3 and a warning in nih_export_clap

### DIFF
--- a/src/wrapper/clap.rs
+++ b/src/wrapper/clap.rs
@@ -82,7 +82,7 @@ macro_rules! nih_export_clap {
             }
 
             unsafe extern "C" fn create_plugin (
-                factory: *const clap_plugin_factory,
+                _factory: *const clap_plugin_factory,
                 host: *const clap_host,
                 plugin_id: *const c_char,
             ) -> *const clap_plugin  {

--- a/src/wrapper/vst3.rs
+++ b/src/wrapper/vst3.rs
@@ -59,7 +59,7 @@ macro_rules! nih_export_vst3 {
 
                     if cfg!(debug_assertions) {
                         let unique_cids: HashSet<[u8; 16]> = plugin_infos.iter().map(|d| *d.cid).collect();
-                        nih_debug_assert_eq!(
+                        $crate::nih_debug_assert_eq!(
                             unique_cids.len(),
                             plugin_infos.len(),
                             "Duplicate VST3 class IDs found in `nih_export_vst3!()` call"


### PR DESCRIPTION
- The `nih_export_vst3!` expected you to import `nih_debug_assert_eq!`
- There was an "unused" variable warning in `nih_export_clap!`.

I thought I'd make a tiny PR that fixes both :)