### PR TITLE
nih_plug_iced: Pin baseview to the same git version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,24 +447,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "baseview"
-version = "0.1.0"
-source = "git+https://github.com/RustAudio/baseview.git#c129b12ead4f5ac02126f559ceb8ce43cc982200"
-dependencies = [
- "cocoa",
- "core-foundation",
- "keyboard-types",
- "nix 0.22.3",
- "objc",
- "raw-window-handle 0.4.3",
- "uuid",
- "winapi",
- "x11",
- "xcb 0.9.0",
- "xcb-util",
-]
-
-[[package]]
 name = "bindgen"
 version = "0.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1931,9 +1913,9 @@ checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 [[package]]
 name = "iced_baseview"
 version = "0.0.3"
-source = "git+https://github.com/robbert-vdh/iced_baseview.git?branch=feature/update-baseview#07f1b07d3a8bf2a9af0ce6ee57443105ac99de33"
+source = "git+https://github.com/robbert-vdh/iced_baseview.git?rev=df3a852a15cf0e9fcc8d2b32f5718e56780beaf3#df3a852a15cf0e9fcc8d2b32f5718e56780beaf3"
 dependencies = [
- "baseview 0.1.0 (git+https://github.com/RustAudio/baseview.git)",
+ "baseview 0.1.0 (git+https://github.com/RustAudio/baseview.git?rev=1d9806d5bd92275d0d8142d9c9c90198757b9b25)",
  "copypasta 0.7.1",
  "iced_core",
  "iced_futures",
@@ -2602,7 +2584,7 @@ name = "nih_plug_iced"
 version = "0.0.0"
 dependencies = [
  "atomic_refcell",
- "baseview 0.1.0 (git+https://github.com/RustAudio/baseview.git)",
+ "baseview 0.1.0 (git+https://github.com/RustAudio/baseview.git?rev=1d9806d5bd92275d0d8142d9c9c90198757b9b25)",
  "crossbeam",
  "iced_baseview",
  "nih_plug",

--- a/nih_plug_iced/Cargo.toml
+++ b/nih_plug_iced/Cargo.toml
@@ -60,10 +60,10 @@ nih_plug = { path = ".." }
 nih_plug_assets = { git = "https://github.com/robbert-vdh/nih_plug_assets.git" }
 
 atomic_refcell = "0.1"
-baseview = { git = "https://github.com/RustAudio/baseview.git" }
+baseview = { git = "https://github.com/RustAudio/baseview.git", rev = "1d9806d5bd92275d0d8142d9c9c90198757b9b25", features = ["opengl"]  }
 crossbeam = "0.8"
 # Upstream doesn't work with the current iced version, this branch also contains
 # additional features
-iced_baseview = { git = "https://github.com/robbert-vdh/iced_baseview.git", branch = "feature/update-baseview", default_features = false }
+iced_baseview = { git = "https://github.com/robbert-vdh/iced_baseview.git", rev = "df3a852a15cf0e9fcc8d2b32f5718e56780beaf3", default_features = false }
 # To make the state persistable
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
I had issues using `nih_plug_iced` for a plugin, because the `baseview` packages aren't the same (with a new Cargo.lock).
This should pin them to the same version, the feature `opengl` seems to be also needed in the pinned baseview version.

(I generally think a reexport in `iced_baseview` of `baseview` may be more robust though).