### PR TITLE
fix panic when setting mouse cursor in nih_plug_egui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Since there is no stable release yet, the changes are organized per day in
 reverse chronological order. The main purpose of this document in its current
 state is to list breaking changes.
 
+## [2024-02-23]
+
+### Fixed
+
+- Fixed `nih_plug_egui` panicking due to cursor icons not yet being implemented in baseview for MacOS and Windows.
+
 ## [2024-02-22]
 
 ### Breaking changes

--- a/nih_plug_egui/Cargo.toml
+++ b/nih_plug_egui/Cargo.toml
@@ -20,7 +20,7 @@ nih_plug = { path = ".." }
 raw-window-handle = "0.5"
 baseview = { git = "https://github.com/RustAudio/baseview.git", rev = "2c1b1a7b0fef1a29a5150a6a8f6fef6a0cbab8c4" }
 crossbeam = "0.8"
-egui-baseview = { git = "https://github.com/BillyDM/egui-baseview.git", rev = "1fe7e1d0081ab29474b0a5cdc567f60a3219b20d", default-features = false }
+egui-baseview = { git = "https://github.com/BillyDM/egui-baseview.git", rev = "bd3c50d0b6de8d5cf526a9b9d089a2a2c0249900", default-features = false }
 lazy_static = "1.4"
 parking_lot = "0.12"
 # To make the state persistable


### PR DESCRIPTION
I didn't realize that mouse cursor support in baseview is currently only implemented for Linux. This commit fixes a panic when trying to set the mouse cursor in MacOS or Windows.