### PR TITLE
add new ParamSliderStyle::FromMidPoint

### DIFF
--- a/nih_plug_vizia/src/widgets/param_slider.rs
+++ b/nih_plug_vizia/src/widgets/param_slider.rs
@@ -49,9 +49,11 @@ pub enum ParamSliderStyle {
     Centered,
     /// Always fill the bar starting from the left.
     FromLeft,
+    /// Fill the bar from the mid point, regardless of where the default value lies
+    FromMidPoint,
     /// Show the current step instead of filling a portion of the bar, useful for discrete
     /// parameters. Set `even` to `true` to distribute the ticks evenly instead of following the
-    /// parameter's distribution. This can be desireable because discrete parameters have smaller
+    /// parameter's distribution. This can be desirable because discrete parameters have smaller
     /// ranges near the edges (they'll span only half the range, which can make the display look
     /// odd).
     CurrentStep { even: bool },
@@ -333,6 +335,16 @@ impl ParamSlider {
                     if delta >= 1e-3 { delta } else { 0.0 },
                 )
             }
+            ParamSliderStyle::FromMidPoint => {
+                let delta = (0.5 - current_value).abs();
+
+                // Don't draw the filled portion at all if it could have been a
+                // rounding error since those slivers just look weird
+                (
+                    0.5_f32.min(current_value),
+                    if delta >= 1e-3 { delta } else { 0.0 },
+                )
+            }
             ParamSliderStyle::Centered | ParamSliderStyle::FromLeft => (0.0, current_value),
             ParamSliderStyle::CurrentStep { even: true }
             | ParamSliderStyle::CurrentStepLabeled { even: true }
@@ -369,7 +381,9 @@ impl ParamSlider {
             ParamSliderStyle::CurrentStep { .. } | ParamSliderStyle::CurrentStepLabeled { .. } => {
                 (0.0, 0.0)
             }
-            ParamSliderStyle::Centered | ParamSliderStyle::FromLeft => {
+            ParamSliderStyle::Centered
+            | ParamSliderStyle::FromMidPoint
+            | ParamSliderStyle::FromLeft => {
                 let modulation_start = param.unmodulated_normalized_value();
 
                 (


### PR DESCRIPTION
In cases like a modulation amount slider that has the same negative and positive range, you might want the default value to be non zero, so your user gets some modulation when they open your plugin for the first time.
At the same time, you want them to draw starting from the mid point, and not from the default value. 

I have minimal comments, and I'm not sure about the name.
I wanted to get your feedback first.

PS: my editor wouldn't let me commit before I fixed the typo...  ¯\\\_(ツ)\_/¯