### PR TITLE
Use upstream clap-sys, CLAP 1.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -946,8 +946,8 @@ dependencies = [
 
 [[package]]
 name = "clap-sys"
-version = "0.3.0"
-source = "git+https://github.com/robbert-vdh/clap-sys.git?branch=feature/cstr-macro#523a5f8a8dd021ec99e7d6e0c0ebe7741a3da9d4"
+version = "0.5.0"
+source = "git+https://github.com/micahrj/clap-sys.git?rev=25d7f53fdb6363ad63fbd80049cb7a42a97ac156#25d7f53fdb6363ad63fbd80049cb7a42a97ac156"
 
 [[package]]
 name = "clap_builder"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,8 +82,8 @@ atomic_refcell = "0.1"
 backtrace = "0.3.65"
 bitflags = "1.3"
 cfg-if = "1.0"
-# This supports CLAP 1.1.8
-clap-sys = {  git = "https://github.com/robbert-vdh/clap-sys.git", branch = "feature/cstr-macro" }
+# This supports CLAP 1.2.2
+clap-sys = {  git = "https://github.com/micahrj/clap-sys.git", rev = "25d7f53fdb6363ad63fbd80049cb7a42a97ac156" }
 crossbeam = "0.8"
 log = { version = "0.4", features = ["std", "release_max_level_info"] }
 midi-consts = "0.1"

--- a/src/wrapper/clap/context.rs
+++ b/src/wrapper/clap/context.rs
@@ -1,5 +1,5 @@
 use atomic_refcell::AtomicRefMut;
-use clap_sys::ext::draft::remote_controls::{
+use clap_sys::ext::remote_controls::{
     clap_remote_controls_page, CLAP_REMOTE_CONTROLS_COUNT,
 };
 use clap_sys::id::{clap_id, CLAP_INVALID_ID};

--- a/src/wrapper/clap/wrapper.rs
+++ b/src/wrapper/clap/wrapper.rs
@@ -22,7 +22,7 @@ use clap_sys::ext::audio_ports::{
 use clap_sys::ext::audio_ports_config::{
     clap_audio_ports_config, clap_plugin_audio_ports_config, CLAP_EXT_AUDIO_PORTS_CONFIG,
 };
-use clap_sys::ext::draft::remote_controls::{
+use clap_sys::ext::remote_controls::{
     clap_plugin_remote_controls, clap_remote_controls_page, CLAP_EXT_REMOTE_CONTROLS,
 };
 use clap_sys::ext::gui::{


### PR DESCRIPTION
Upstream clap-sys at https://github.com/micahrj/clap-sys seems to have accepted pull requests from https://github.com/robbert-vdh/clap-sys and updated the version of CLAP supported.

It appears as though https://github.com/robbert-vdh/clap-sys is no longer required.

Pinned dependency to upstream clap-sys v0.5.0 which supports CLAP 1.2.2.
Minor edits for some extensions which were stabilized between CLAP 1.1.8 and CLAP 1.2.2.