### PR TITLE
Allow the Editor to define if the host may request window sizing

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -45,6 +45,16 @@ pub trait Editor: Send {
     /// scaling factor to get the actual physical screen pixels.
     fn size(&self) -> (u32, u32);
 
+    /// Set the size of the editor in pixels. This size must be in _logical pixels_, i.e. the size
+    /// before being multiplied by the DPI scaling factor to get the actual physical screen pixels.
+    /// This function should return `true` if the size was successfully set, and `false` if the editor
+    /// rejected the size change.
+    fn set_size(&self, _width: u32, _height: u32) -> bool { false }
+
+    /// Returns whether the editor can be resized. If this returns `false`, then the host will not
+    /// show a resize handle on the editor window.
+    fn can_resize(&self) -> bool { false }
+
     /// Set the DPI scaling factor, if supported. The plugin APIs don't make any guarantees on when
     /// this is called, but for now just assume it will be the first function that gets called
     /// before creating the editor. If this is set, then any windows created by this editor should
@@ -73,7 +83,6 @@ pub trait Editor: Send {
     //       and API agnostic, add a way to ask the GuiContext if the wrapper already provides a
     //       tick function. If it does not, then the Editor implementation must handle this by
     //       itself. This would also need an associated `PREFERRED_FRAME_RATE` constant.
-    // TODO: Host->Plugin resizing
 }
 
 /// A raw window handle for platform and GUI framework agnostic editors. This implements

--- a/src/wrapper/vst3/view.rs
+++ b/src/wrapper/vst3/view.rs
@@ -376,7 +376,6 @@ impl<P: Vst3Plugin> IPlugView for WrapperView<P> {
     unsafe fn on_size(&self, new_size: *mut ViewRect) -> tresult {
         check_null_ptr!(new_size);
 
-        // TODO: Implement Host->Plugin resizing
         let (unscaled_width, unscaled_height) = self.editor.lock().size();
         let scaling_factor = self.scaling_factor.load(Ordering::Relaxed);
         let (editor_width, editor_height) = (
@@ -384,12 +383,28 @@ impl<P: Vst3Plugin> IPlugView for WrapperView<P> {
             (unscaled_height as f32 * scaling_factor).round() as i32,
         );
 
-        let width = (*new_size).right - (*new_size).left;
-        let height = (*new_size).bottom - (*new_size).top;
-        if width == editor_width && height == editor_height {
-            kResultOk
+        if self.editor.lock().can_resize() {
+            let (unscaled_new_width, unscaled_new_height) = (
+                (*new_size).right - (*new_size).left,
+                (*new_size).bottom - (*new_size).top,
+            );
+            let (new_width, new_height) = (
+                (unscaled_new_width as f32 * scaling_factor).round() as i32,
+                (unscaled_new_height as f32 * scaling_factor).round() as i32,
+            );
+            if self.editor.lock().set_size(new_width as u32, new_height as u32) {
+                kResultOk
+            } else {
+                kResultFalse
+            }
         } else {
-            kResultFalse
+            let width = (*new_size).right - (*new_size).left;
+            let height = (*new_size).bottom - (*new_size).top;
+            if width == editor_width && height == editor_height {
+                kResultOk
+            } else {
+                kResultFalse
+            }
         }
     }
 
@@ -425,8 +440,11 @@ impl<P: Vst3Plugin> IPlugView for WrapperView<P> {
     }
 
     unsafe fn can_resize(&self) -> tresult {
-        // TODO: Implement Host->Plugin resizing
-        kResultFalse
+        if self.editor.lock().can_resize() {
+            kResultOk
+        } else {
+            kResultFalse
+        }
     }
 
     unsafe fn check_size_constraint(&self, rect: *mut ViewRect) -> tresult {


### PR DESCRIPTION
Currently, the wrappers have the hosts requests for window resizing hardcoded to false. I propose to forward this decision to the implementation of the `Editor`. 

Please let me know if there are any concerns or design discussions to be made.

This PR does not functionally change any existing plugins, the default is still to return `false` to the host when it asks if it may resize the window.