### PR TITLE
switch to anymap3 instead of anymap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,10 +257,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
-name = "anymap"
-version = "1.0.0-beta.2"
+name = "anymap3"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1f8f5a6f3d50d89e3797d7593a50f96bb2aaa20ca0cc7be1fb673232c91d72"
+checksum = "170433209e817da6aae2c51aa0dd443009a613425dd041ebfb2492d1c4c11a25"
 
 [[package]]
 name = "approx"
@@ -3039,7 +3039,7 @@ name = "nih_plug"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "anymap",
+ "anymap3",
  "approx 0.5.1",
  "assert_no_alloc",
  "atomic_float",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,34 +13,34 @@ repository = "https://github.com/robbert-vdh/nih-plug"
 [workspace]
 resolver = "2"
 members = [
-  "nih_plug_derive",
-  "nih_plug_egui",
-  "nih_plug_iced",
-  "nih_plug_vizia",
-  "nih_plug_xtask",
+    "nih_plug_derive",
+    "nih_plug_egui",
+    "nih_plug_iced",
+    "nih_plug_vizia",
+    "nih_plug_xtask",
 
-  "cargo_nih_plug",
-  "xtask",
+    "cargo_nih_plug",
+    "xtask",
 
-  "plugins/examples/gain",
-  "plugins/examples/gain_gui_egui",
-  "plugins/examples/gain_gui_iced",
-  "plugins/examples/gain_gui_vizia",
-  "plugins/examples/midi_inverter",
-  "plugins/examples/poly_mod_synth",
-  "plugins/examples/sine",
-  "plugins/examples/stft",
-  "plugins/examples/sysex",
+    "plugins/examples/gain",
+    "plugins/examples/gain_gui_egui",
+    "plugins/examples/gain_gui_iced",
+    "plugins/examples/gain_gui_vizia",
+    "plugins/examples/midi_inverter",
+    "plugins/examples/poly_mod_synth",
+    "plugins/examples/sine",
+    "plugins/examples/stft",
+    "plugins/examples/sysex",
 
-  "plugins/soft_vacuum",
-  "plugins/buffr_glitch",
-  "plugins/crisp",
-  "plugins/crossover",
-  "plugins/diopser",
-  "plugins/loudness_war_winner",
-  "plugins/puberty_simulator",
-  "plugins/safety_limiter",
-  "plugins/spectral_compressor",
+    "plugins/soft_vacuum",
+    "plugins/buffr_glitch",
+    "plugins/crisp",
+    "plugins/crossover",
+    "plugins/diopser",
+    "plugins/loudness_war_winner",
+    "plugins/puberty_simulator",
+    "plugins/safety_limiter",
+    "plugins/spectral_compressor",
 ]
 
 [features]
@@ -54,7 +54,14 @@ assert_process_allocs = ["dep:assert_no_alloc"]
 # Enables an export target for standalone binaries through the
 # `nih_export_standalone()` function. Disabled by default as this requires
 # building additional dependencies for audio and MIDI handling.
-standalone = ["dep:baseview", "dep:clap", "dep:cpal", "dep:jack", "dep:midir", "dep:rtrb"]
+standalone = [
+    "dep:baseview",
+    "dep:clap",
+    "dep:cpal",
+    "dep:jack",
+    "dep:midir",
+    "dep:rtrb",
+]
 # Enables the `nih_export_vst3!()` macro. Enabled by default. This feature
 # exists mostly for GPL-compliance reasons, since even if you don't use the VST3
 # wrapper you might otherwise still include a couple (unused) symbols from the
@@ -76,14 +83,14 @@ docs = []
 nih_plug_derive = { path = "nih_plug_derive" }
 
 anyhow = "1.0"
-anymap = "1.0.0-beta.2"
+anymap3 = "1.0.1"
 atomic_float = "0.1"
 atomic_refcell = "0.1"
 backtrace = "0.3.65"
 bitflags = "1.3"
 cfg-if = "1.0"
 # This supports CLAP 1.1.8
-clap-sys = {  git = "https://github.com/robbert-vdh/clap-sys.git", branch = "feature/cstr-macro" }
+clap-sys = { git = "https://github.com/robbert-vdh/clap-sys.git", branch = "feature/cstr-macro" }
 crossbeam = "0.8"
 log = { version = "0.4", features = ["std", "release_max_level_info"] }
 midi-consts = "0.1"
@@ -95,14 +102,22 @@ serde_json = "1.0"
 widestring = "1.0.0-beta.1"
 
 # Used for the `assert_process_allocs` feature
-assert_no_alloc = { git = "https://github.com/robbert-vdh/rust-assert-no-alloc.git", branch = "feature/nested-permit-forbid", features = ["backtrace", "log"], optional = true }
+assert_no_alloc = { git = "https://github.com/robbert-vdh/rust-assert-no-alloc.git", branch = "feature/nested-permit-forbid", features = [
+    "backtrace",
+    "log",
+], optional = true }
 
 # Used for the `standalone` feature
 # NOTE: OpenGL support is not needed here, but rust-analyzer gets confused when
 #       some crates do use it and others don't
-baseview = { git = "https://github.com/RustAudio/baseview.git", rev = "579130ecb4f9f315ae52190af42f0ea46aeaa4a2", features = ["opengl"], optional = true }
+baseview = { git = "https://github.com/RustAudio/baseview.git", rev = "579130ecb4f9f315ae52190af42f0ea46aeaa4a2", features = [
+    "opengl",
+], optional = true }
 # All the claps!
-clap = { version = "4.1.8", features = ["derive", "wrap_help"], optional = true }
+clap = { version = "4.1.8", features = [
+    "derive",
+    "wrap_help",
+], optional = true }
 cpal = { version = "0.15", optional = true }
 jack = { version = "0.11.4", optional = true }
 midir = { version = "0.9.1", optional = true }
@@ -127,11 +142,11 @@ core-foundation = "0.9.3"
 [target.'cfg(target_os = "windows")'.dependencies.windows]
 version = "0.44"
 features = [
-  "Win32_Foundation",
-  "Win32_Graphics_Gdi",
-  "Win32_UI_WindowsAndMessaging",
-  "Win32_System_LibraryLoader",
-  "Win32_System_Performance",
+    "Win32_Foundation",
+    "Win32_Graphics_Gdi",
+    "Win32_UI_WindowsAndMessaging",
+    "Win32_System_LibraryLoader",
+    "Win32_System_Performance",
 ]
 
 [profile.release]

--- a/src/event_loop/background_thread.rs
+++ b/src/event_loop/background_thread.rs
@@ -71,8 +71,8 @@ where
 }
 
 // Rust does not allow us to use the `T` and `E` type variable in statics, so this is a
-// workaround to have a singleton that also works if for whatever reason there arem ultiple `T`
-// and `E`s in a single process (won't happen with normal plugin usage, but sho knwos).
+// workaround to have a singleton that also works if for whatever reason there are multiple `T`
+// and `E`s in a single process (won't happen with normal plugin usage, but who knows).
 static HANDLE_MAP: LazyLock<Mutex<anymap3::Map<dyn std::any::Any + Send>>> =
     LazyLock::new(|| Mutex::new(anymap3::Map::new()));
 

--- a/src/event_loop/background_thread.rs
+++ b/src/event_loop/background_thread.rs
@@ -3,7 +3,7 @@
 //!
 //! This is essentially a slimmed down version of the `LinuxEventLoop`.
 
-use anymap::Entry;
+use anymap3::Entry;
 use crossbeam::channel;
 use parking_lot::Mutex;
 use std::sync::{Arc, LazyLock, Weak};
@@ -73,8 +73,8 @@ where
 // Rust does not allow us to use the `T` and `E` type variable in statics, so this is a
 // workaround to have a singleton that also works if for whatever reason there arem ultiple `T`
 // and `E`s in a single process (won't happen with normal plugin usage, but sho knwos).
-static HANDLE_MAP: LazyLock<Mutex<anymap::Map<dyn std::any::Any + Send>>> =
-    LazyLock::new(|| Mutex::new(anymap::Map::new()));
+static HANDLE_MAP: LazyLock<Mutex<anymap3::Map<dyn std::any::Any + Send>>> =
+    LazyLock::new(|| Mutex::new(anymap3::Map::new()));
 
 impl<T: Send + 'static, E: MainThreadExecutor<T> + 'static> WorkerThread<T, E> {
     fn spawn() -> Self {


### PR DESCRIPTION
recently cargo has been giving a future incompatibility warning for anymap, see https://github.com/rust-lang/rust/issues/127323 for context.

since it's most likely that anymap will not be updated, this is a drop in futureproofing measure.

i also fixed a doc typo while i was at it