### PR TITLE
Correct group parameter name in `Params` struct's attribute docs

### DIFF
--- a/src/params.rs
+++ b/src/params.rs
@@ -249,7 +249,7 @@ pub(crate) trait ParamMut: Param {
 /// with the `#[persist = "key"]` attribute containing types that can be serialized and deserialized
 /// with [Serde](https://serde.rs/).
 ///
-/// ## `#[nested]`, `#[nested(group_name = "group name")]`
+/// ## `#[nested]`, `#[nested(group = "group name")]`
 ///
 /// Finally, the `Params` object may include parameters from other objects. Setting a group name is
 /// optional, but some hosts can use this information to display the parameters in a tree structure.
@@ -258,7 +258,7 @@ pub(crate) trait ParamMut: Param {
 ///
 /// Take a look at the example gain example plugin to see how this is used.
 ///
-/// ## `#[nested(id_prefix = "foo", group_name = "Foo")]`
+/// ## `#[nested(id_prefix = "foo", group = "Foo")]`
 ///
 /// Adding this attribute to a `Params` sub-object works similarly to the regular `#[nested]`
 /// attribute, but it also adds an ID to all parameters from the nested object. If a parameter in
@@ -267,7 +267,7 @@ pub(crate) trait ParamMut: Param {
 /// the field. _This makes it possible to reuse the same parameter struct with different names and
 /// parameter indices._
 ///
-/// ## `#[nested(array, group_name = "Foo")]`
+/// ## `#[nested(array, group = "Foo")]`
 ///
 /// This can be applied to an array-like data structure and it works similar to a `nested` attribute
 /// with an `id_name`, except that it will iterate over the array and create unique indices for all


### PR DESCRIPTION
This corrects a small error in the `Params` struct's docs where the attribute that should be `group` is documented as `group_name` e.g.
https://github.com/robbert-vdh/nih-plug/blob/400eb3156f221073fbcaf95607b56842272d134b/src/params.rs#L252

Definition of the attribute in the derive crate:

https://github.com/robbert-vdh/nih-plug/blob/400eb3156f221073fbcaf95607b56842272d134b/nih_plug_derive/src/params.rs#L135-L137

https://github.com/robbert-vdh/nih-plug/blob/400eb3156f221073fbcaf95607b56842272d134b/nih_plug_derive/src/params.rs#L179

# Demo

### Use of the documented attribute name fails to compile
```rust
pub struct NightgrainParams {
    #[persist = "editor-state"]
    pub editor_state: Arc<ViziaState>,

    #[nested(array, group_name = "Grain Parameters")]
    pub grain_params: [Arc<GrainParams>; GRAIN_OSC_COUNT],
}
```

```
$ cargo xtask bundle nightgrain                                                                                                                                                                                                        25-04-06 12:29:56 (1)
    Finished `release` profile [optimized] target(s) in 0.06s
     Running `target/release/xtask bundle nightgrain`
   Compiling nightgrain v0.1.0 (/home/leaf/c/music/r/nightgrain/nightgrain)
error: Unknown attribute. See the Params trait documentation for more information.
  --> nightgrain/src/params.rs:23:21
   |
23 |     #[nested(array, group_name = "Grain Parameters")]
   |                     ^^^^^^^^^^

...
```

### Use of the correct attribute name compiles
```rust
#[derive(Params)]
pub struct NightgrainParams {
    #[persist = "editor-state"]
    pub editor_state: Arc<ViziaState>,

    #[nested(array, group = "Grain Parameters")]
    pub grain_params: [Arc<GrainParams>; GRAIN_OSC_COUNT],
}
```

```
 $ cargo xtask bundle nightgrain                                                                                                                                                                                                        25-04-06 12:33:46 (0)
    Finished `release` profile [optimized] target(s) in 0.06s
     Running `target/release/xtask bundle nightgrain`
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.08s

Created a VST3 bundle at '/home/leaf/c/music/r/nightgrain/target/bundled/nightgrain.vst3'       
```