### PR TITLE
Add default-features=false

### DIFF
--- a/nih_plug_egui/Cargo.toml
+++ b/nih_plug_egui/Cargo.toml
@@ -20,7 +20,7 @@ nih_plug = { path = "..", default-features = false }
 raw-window-handle = "0.5"
 baseview = { git = "https://github.com/RustAudio/baseview.git", rev = "9a0b42c09d712777b2edb4c5e0cb6baf21e988f0" }
 crossbeam = "0.8"
-egui-baseview = { git = "https://github.com/BillyDM/egui-baseview.git", rev = "ec70c3fe6b2f070dcacbc22924431edbe24bd1c0" }
+egui-baseview = { git = "https://github.com/BillyDM/egui-baseview.git", rev = "ec70c3fe6b2f070dcacbc22924431edbe24bd1c0", default-features = false }
 parking_lot = "0.12"
 # To make the state persistable
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Hi, thank you for creating and maintaining this library.

While developing a VST plugin with nih-plug, I noticed that [epaint_default_fonts](https://github.com/emilk/egui/tree/1669e52a7ccfc3489c1b0999b9ed48894a0b3887/crates/epaint_default_fonts)—which has a GPL-incompatible license—is pulled in via nih-plug-egui, even when I try to disable `default-features`:

```diff
-nih_plug_egui = { git = "...", rev = "..." }
+nih_plug_egui = { git = "...", rev = "...", default-features = false, features = ["opengl"] }
```

It seems egui-baseview is included with `default-features` enabled by default. This PR disables them, so users can opt into only the features they need.