### PR TITLE
fix transparency in softbuffer example

### DIFF
--- a/plugins/examples/byo_gui_softbuffer/src/lib.rs
+++ b/plugins/examples/byo_gui_softbuffer/src/lib.rs
@@ -81,8 +81,10 @@ impl baseview::WindowHandler for CustomSoftbufferWindow {
                 let red = x % 255;
                 let green = y % 255;
                 let blue = (x * y) % 255;
+                let alpha = 255;
+
                 let index = y as usize * self.physical_width as usize + x as usize;
-                buffer[index] = blue | (green << 8) | (red << 16);
+                buffer[index] = blue | (green << 8) | (red << 16) | (alpha << 24);
             }
         }
 


### PR DESCRIPTION
Fixing the transparency issue in KDE turned out to be easy, I just needed to set the alpha channel for each pixel.