### PR TITLE
Expose process stopped

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -243,6 +243,19 @@ pub trait Plugin: Default + Send + 'static {
         context: &mut impl ProcessContext<Self>,
     ) -> ProcessStatus;
 
+    /// Called when audio processing stops, for instance when the plugin is turned off.
+    /// This is the counterpart to [`reset()`][Self::reset()] which is called
+    /// when processing starts or resumes.
+    ///
+    /// Unlike [`deactivate()`][Self::deactivate()], this is called for temporary processing
+    /// interruptions like bypassing, not major lifecycle changes.
+    /// You can use this to gracefully handle the transition to a non-processing state, such as clearing
+    /// buffers, writing silence to displays, or saving state.
+    ///
+    /// This method is called from both CLAP (`stop_processing`) and VST3 (`setProcessing(false)`)
+    /// hosts when they temporarily stop sending audio to the plugin.
+    fn process_stopped(&mut self) {}
+
     /// Called when the plugin is deactivated. The host will call
     /// [`initialize()`][Self::initialize()] again before the plugin resumes processing audio. These
     /// two functions will not be called when the host only temporarily stops processing audio. You

--- a/src/wrapper/clap/wrapper.rs
+++ b/src/wrapper/clap/wrapper.rs
@@ -1939,6 +1939,10 @@ impl<P: ClapPlugin> Wrapper<P> {
         let wrapper = &*((*plugin).plugin_data as *const Self);
 
         wrapper.is_processing.store(false, Ordering::SeqCst);
+
+        process_wrapper(|| {
+            wrapper.plugin.lock().process_stopped();
+        });
     }
 
     unsafe extern "C" fn reset(plugin: *const clap_plugin) {

--- a/src/wrapper/vst3/wrapper.rs
+++ b/src/wrapper/vst3/wrapper.rs
@@ -922,6 +922,11 @@ impl<P: Vst3Plugin> IAudioProcessor for Wrapper<P> {
             };
 
             process_wrapper(|| plugin.reset());
+        } else {
+            // Process stopped - call the plugin's process_stopped() method
+            process_wrapper(|| {
+                self.inner.plugin.lock().process_stopped();
+            });
         }
 
         // We don't have any special handling for suspending and resuming plugins, yet


### PR DESCRIPTION
I was trying to find a way to gracefully handle my plugin being turned off by the DAW. For my scenario I wanted to create a decay to the spectrum analyser animation and grey out the whole plugin:
![2025-09-20 13 01 04](https://github.com/user-attachments/assets/fcc89cb7-1308-4ecd-b85f-1f7a6718f836)

Prior to this addition the spectrum would just hang on the last buffer coming from process and there was no trigger to dictate process was no longer sending any information.

I'm unsure if the name is correct, happy to change and the function is purely optional so will be backwards compatible.