### PR TITLE
Move to non-forked vst3-sys crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6037,7 +6037,7 @@ dependencies = [
 [[package]]
 name = "vst3-com"
 version = "0.1.0"
-source = "git+https://github.com/robbert-vdh/vst3-sys.git?branch=fix/drop-box-from-raw#b3ff4d775940f5b476b9d1cca02a90e07e1922a2"
+source = "git+https://github.com/RustAudio/vst3-sys#f3e8f01c3de6d5df2f503c920c9f2bf8166a771b"
 dependencies = [
  "vst3-com-macros",
 ]
@@ -6045,7 +6045,7 @@ dependencies = [
 [[package]]
 name = "vst3-com-macros"
 version = "0.2.0"
-source = "git+https://github.com/robbert-vdh/vst3-sys.git?branch=fix/drop-box-from-raw#b3ff4d775940f5b476b9d1cca02a90e07e1922a2"
+source = "git+https://github.com/RustAudio/vst3-sys#f3e8f01c3de6d5df2f503c920c9f2bf8166a771b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6056,7 +6056,7 @@ dependencies = [
 [[package]]
 name = "vst3-com-macros-support"
 version = "0.2.0"
-source = "git+https://github.com/robbert-vdh/vst3-sys.git?branch=fix/drop-box-from-raw#b3ff4d775940f5b476b9d1cca02a90e07e1922a2"
+source = "git+https://github.com/RustAudio/vst3-sys#f3e8f01c3de6d5df2f503c920c9f2bf8166a771b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6066,7 +6066,7 @@ dependencies = [
 [[package]]
 name = "vst3-sys"
 version = "0.1.0"
-source = "git+https://github.com/robbert-vdh/vst3-sys.git?branch=fix/drop-box-from-raw#b3ff4d775940f5b476b9d1cca02a90e07e1922a2"
+source = "git+https://github.com/RustAudio/vst3-sys#f3e8f01c3de6d5df2f503c920c9f2bf8166a771b"
 dependencies = [
  "vst3-com",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,7 @@ midir = { version = "0.9.1", optional = true }
 rtrb = { version = "0.2.2", optional = true }
 
 # Used for the `vst3` feature
-vst3-sys = { git = "https://github.com/robbert-vdh/vst3-sys.git", branch = "fix/drop-box-from-raw", optional = true }
+vst3-sys = { git = "https://github.com/RustAudio/vst3-sys", optional = true }
 
 # Used for the `zstd` feature
 zstd = { version = "0.12.3", optional = true }


### PR DESCRIPTION
Previously the forked version of vst3-sys was used, due to an [extra fix](https://github.com/robbert-vdh/vst3-sys/commit/b3ff4d775940f5b476b9d1cca02a90e07e1922a2) being implemented on the specified branch. However this has now been [fixed in the main repo](https://github.com/RustAudio/vst3-sys/pull/52). 

Using the forked branch means that we don't get some other fixes that were made in the main crate when using nih-plug, [this one](https://github.com/RustAudio/vst3-sys/commit/521b3d9746412b90eb697c903855b583f2e026ae) in particular would be useful to have as currently cargo deny complains about the license formatting. 

In any case it seems simpler to move over to the main repo rather than maintaining a separate fork. 