### PR TITLE
Add ProcessContext parameter setting support

### DIFF
--- a/src/context/process.rs
+++ b/src/context/process.rs
@@ -1,7 +1,7 @@
 //! A context passed during the process function.
 
 use super::PluginApi;
-use crate::prelude::{Plugin, PluginNoteEvent};
+use crate::prelude::{ParamPtr, Plugin, PluginNoteEvent};
 
 /// Contains both context data and callbacks the plugin can use during processing. Most notably this
 /// is how a plugin sends and receives note events, gets transport information, and accesses
@@ -92,10 +92,43 @@ pub trait ProcessContext<P: Plugin> {
     /// monophonic modulation when dropping the capacity down to 1.
     fn set_current_voice_capacity(&self, capacity: u32);
 
-    // TODO: Add this, this works similar to [GuiContext::set_parameter] but it adds the parameter
-    //       change to a queue (or directly to the VST3 plugin's parameter output queues) instead of
-    //       using main thread host automation (and all the locks involved there).
-    // fn set_parameter<P: Param>(&self, param: &P, value: P::Plain);
+    /// Inform the host that a parameter will be automated. This queues the event to be sent to the
+    /// host at the end of the current processing cycle. This should be called before calling
+    /// [`raw_set_parameter_normalized()`][Self::raw_set_parameter_normalized()] for the specified
+    /// parameter. Create a [`ParamSetter`] and use
+    /// [`ParamSetter::begin_set_parameter()`][crate::prelude::ParamSetter::begin_set_parameter()]
+    /// instead for a safe, user friendly API.
+    ///
+    /// # Safety
+    ///
+    /// The implementing function still needs to check if `param` actually exists. This function is
+    /// mostly marked as unsafe for API reasons.
+    unsafe fn raw_begin_set_parameter(&self, param: ParamPtr);
+
+    /// Inform the host that a parameter is being automated with an already normalized value. This
+    /// queues the event to be sent to the host at the end of the current processing cycle. Create
+    /// a [`ParamSetter`] and use
+    /// [`ParamSetter::set_parameter()`][crate::prelude::ParamSetter::set_parameter()] instead for
+    /// a safe, user friendly API.
+    ///
+    /// # Safety
+    ///
+    /// The implementing function still needs to check if `param` actually exists. This function is
+    /// mostly marked as unsafe for API reasons.
+    unsafe fn raw_set_parameter_normalized(&self, param: ParamPtr, normalized: f32);
+
+    /// Inform the host that a parameter has been automated. This queues the event to be sent to
+    /// the host at the end of the current processing cycle. This should be called after calling
+    /// [`raw_set_parameter_normalized()`][Self::raw_set_parameter_normalized()] for the specified
+    /// parameter. Create a [`ParamSetter`] and use
+    /// [`ParamSetter::end_set_parameter()`][crate::prelude::ParamSetter::end_set_parameter()]
+    /// instead for a safe, user friendly API.
+    ///
+    /// # Safety
+    ///
+    /// The implementing function still needs to check if `param` actually exists. This function is
+    /// mostly marked as unsafe for API reasons.
+    unsafe fn raw_end_set_parameter(&self, param: ParamPtr);
 }
 
 /// Information about the plugin's transport. Depending on the plugin API and the host not all

--- a/src/wrapper/clap/context.rs
+++ b/src/wrapper/clap/context.rs
@@ -127,6 +127,63 @@ impl<P: ClapPlugin> ProcessContext<P> for WrapperProcessContext<'_, P> {
     fn set_current_voice_capacity(&self, capacity: u32) {
         self.wrapper.set_current_voice_capacity(capacity)
     }
+
+    unsafe fn raw_begin_set_parameter(&self, param: ParamPtr) {
+        match self.wrapper.param_ptr_to_hash.get(&param) {
+            Some(hash) => {
+                let success = self
+                    .wrapper
+                    .queue_parameter_event(OutputParamEvent::BeginGesture { param_hash: *hash });
+
+                nih_debug_assert!(
+                    success,
+                    "Parameter output event queue was full, parameter change will not be sent to \
+                     the host"
+                );
+            }
+            None => nih_debug_assert_failure!(
+                "raw_begin_set_parameter() called with an unknown ParamPtr"
+            ),
+        }
+    }
+
+    unsafe fn raw_set_parameter_normalized(&self, param: ParamPtr, normalized: f32) {
+        match self.wrapper.param_ptr_to_hash.get(&param) {
+            Some(hash) => {
+                let clap_plain_value = normalized as f64 * param.step_count().unwrap_or(1) as f64;
+                let success = self
+                    .wrapper
+                    .queue_parameter_event(OutputParamEvent::SetValue {
+                        param_hash: *hash,
+                        clap_plain_value,
+                    });
+
+                nih_debug_assert!(
+                    success,
+                    "Parameter output event queue was full, parameter change will not be sent to \
+                     the host"
+                );
+            }
+            None => nih_debug_assert_failure!("Unknown parameter: {:?}", param),
+        }
+    }
+
+    unsafe fn raw_end_set_parameter(&self, param: ParamPtr) {
+        match self.wrapper.param_ptr_to_hash.get(&param) {
+            Some(hash) => {
+                let success = self
+                    .wrapper
+                    .queue_parameter_event(OutputParamEvent::EndGesture { param_hash: *hash });
+
+                nih_debug_assert!(
+                    success,
+                    "Parameter output event queue was full, parameter change will not be sent to \
+                     the host"
+                );
+            }
+            None => nih_debug_assert_failure!("Unknown parameter: {:?}", param),
+        }
+    }
 }
 
 impl<P: ClapPlugin> GuiContext for WrapperGuiContext<P> {

--- a/src/wrapper/vst3/context.rs
+++ b/src/wrapper/vst3/context.rs
@@ -116,6 +116,55 @@ impl<P: Vst3Plugin> ProcessContext<P> for WrapperProcessContext<'_, P> {
     fn set_current_voice_capacity(&self, _capacity: u32) {
         // This is only supported by CLAP
     }
+
+    unsafe fn raw_begin_set_parameter(&self, param: ParamPtr) {
+        match &*self.inner.component_handler.borrow() {
+            Some(handler) => match self.inner.param_ptr_to_hash.get(&param) {
+                Some(hash) => {
+                    handler.begin_edit(*hash);
+                }
+                None => nih_debug_assert_failure!("Unknown parameter: {:?}", param),
+            },
+            None => nih_debug_assert_failure!("Component handler not yet set"),
+        }
+    }
+
+    unsafe fn raw_set_parameter_normalized(&self, param: ParamPtr, normalized: f32) {
+        match &*self.inner.component_handler.borrow() {
+            Some(handler) => match self.inner.param_ptr_to_hash.get(&param) {
+                Some(hash) => {
+                    // Update the parameter value directly since we're on the audio thread
+                    // The is_processing check ensures we don't update values mid-process
+                    if !self.inner.is_processing.load(Ordering::SeqCst) {
+                        self.inner.set_normalized_value_by_hash(
+                            *hash,
+                            normalized,
+                            self.inner
+                                .current_buffer_config
+                                .load()
+                                .map(|c| c.sample_rate),
+                        );
+                    }
+
+                    handler.perform_edit(*hash, normalized as f64);
+                }
+                None => nih_debug_assert_failure!("Unknown parameter: {:?}", param),
+            },
+            None => nih_debug_assert_failure!("Component handler not yet set"),
+        }
+    }
+
+    unsafe fn raw_end_set_parameter(&self, param: ParamPtr) {
+        match &*self.inner.component_handler.borrow() {
+            Some(handler) => match self.inner.param_ptr_to_hash.get(&param) {
+                Some(hash) => {
+                    handler.end_edit(*hash);
+                }
+                None => nih_debug_assert_failure!("Unknown parameter: {:?}", param),
+            },
+            None => nih_debug_assert_failure!("Component handler not yet set"),
+        }
+    }
 }
 
 impl<P: Vst3Plugin> GuiContext for WrapperGuiContext<P> {


### PR DESCRIPTION
Implement the TODO from src/context/process.rs to add parameter setting capabilities to ProcessContext, enabling plugins to update parameters from the audio thread with proper host notification.

This allows MIDI CC events in the audio thread to record automation and update the GUI in the DAW, similar to how GuiContext works but optimized for real-time safety using lock-free queues.

Changes:
- Added raw_begin_set_parameter(), raw_set_parameter_normalized(), and raw_end_set_parameter() methods to ProcessContext trait
- Implemented for CLAP wrapper using existing queue_parameter_event() infrastructure
- Implemented for VST3 wrapper using component_handler API
- Added ParamPtr import to process.rs

Implementation details:
- CLAP: Uses OutputParamEvent queue with BeginGesture/SetValue/EndGesture
- VST3: Uses component_handler with begin_edit/perform_edit/end_edit
- Both implementations are real-time safe (no allocations, lock-free queues)
- Events queued during process() are sent to host at end of audio cycle

This resolves the long-standing limitation where MIDI CC parameter changes in plugins couldn't notify the host for automation recording.

Tested with: B3 November Hammond organ emulator
Host tested: Reaper (CLAP format)