### PR TITLE
Fix egui window scaling on Retina displays

### DIFF
--- a/nih_plug_egui/src/editor.rs
+++ b/nih_plug_egui/src/editor.rs
@@ -112,7 +112,12 @@ where
                     // Ask the plugin host to resize to self.size()
                     if context.request_resize() {
                         // Resize the content of egui window
-                        queue.resize(PhySize::new(new_size.0, new_size.1));
+                        // Convert logical pixels to physical pixels using the scale factor
+                        let scale = egui_ctx.pixels_per_point();
+                        queue.resize(PhySize::new(
+                            (new_size.0 as f32 * scale) as u32,
+                            (new_size.1 as f32 * scale) as u32,
+                        ));
                         egui_ctx.send_viewport_cmd(ViewportCommand::InnerSize(Vec2::new(
                             new_size.0 as f32,
                             new_size.1 as f32,


### PR DESCRIPTION
On Retina displays, when clicking the draggable element, the UI starts displaying in the lower left part of the window (1/4 of the size).

Convert logical pixels to physical pixels when resizing the window by multiplying by pixels_per_point(). Fixes issue #245 where the egui content would shrink to 1/4 size on macOS Retina displays when dragging the resize handle.

Unfortunately, I haven't tested the fix on Windows or Linux.