### PR TITLE
Fix standalone GUI close race condition and update baseview

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -695,6 +695,23 @@ dependencies = [
 [[package]]
 name = "baseview"
 version = "0.1.0"
+source = "git+https://github.com/RustAudio/baseview.git?rev=237d323c729f3aa99476ba3efa50129c5e86cad3#237d323c729f3aa99476ba3efa50129c5e86cad3"
+dependencies = [
+ "cocoa",
+ "core-foundation 0.9.4",
+ "keyboard-types",
+ "nix 0.22.3",
+ "objc",
+ "raw-window-handle 0.5.2",
+ "uuid",
+ "winapi",
+ "x11",
+ "x11rb 0.13.1",
+]
+
+[[package]]
+name = "baseview"
+version = "0.1.0"
 source = "git+https://github.com/RustAudio/baseview.git?rev=2c1b1a7b0fef1a29a5150a6a8f6fef6a0cbab8c4#2c1b1a7b0fef1a29a5150a6a8f6fef6a0cbab8c4"
 dependencies = [
  "cocoa",
@@ -708,23 +725,6 @@ dependencies = [
  "x11",
  "xcb 0.9.0",
  "xcb-util",
-]
-
-[[package]]
-name = "baseview"
-version = "0.1.0"
-source = "git+https://github.com/RustAudio/baseview.git?rev=579130ecb4f9f315ae52190af42f0ea46aeaa4a2#579130ecb4f9f315ae52190af42f0ea46aeaa4a2"
-dependencies = [
- "cocoa",
- "core-foundation 0.9.4",
- "keyboard-types",
- "nix 0.22.3",
- "objc",
- "raw-window-handle 0.5.2",
- "uuid",
- "winapi",
- "x11",
- "x11rb 0.13.1",
 ]
 
 [[package]]
@@ -3562,7 +3562,7 @@ dependencies = [
  "atomic_float",
  "atomic_refcell",
  "backtrace",
- "baseview 0.1.0 (git+https://github.com/RustAudio/baseview.git?rev=579130ecb4f9f315ae52190af42f0ea46aeaa4a2)",
+ "baseview 0.1.0 (git+https://github.com/RustAudio/baseview.git?rev=237d323c729f3aa99476ba3efa50129c5e86cad3)",
  "bitflags 1.3.2",
  "cfg-if",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ assert_no_alloc = { git = "https://github.com/robbert-vdh/rust-assert-no-alloc.g
 # Used for the `standalone` feature
 # NOTE: OpenGL support is not needed here, but rust-analyzer gets confused when
 #       some crates do use it and others don't
-baseview = { git = "https://github.com/RustAudio/baseview.git", rev = "579130ecb4f9f315ae52190af42f0ea46aeaa4a2", features = ["opengl"], optional = true }
+baseview = { git = "https://github.com/RustAudio/baseview.git", rev = "237d323c729f3aa99476ba3efa50129c5e86cad3", features = ["opengl"], optional = true }
 # All the claps!
 clap = { version = "4.1.8", features = ["derive", "wrap_help"], optional = true }
 cpal = { version = "0.15", optional = true }

--- a/src/wrapper/standalone/wrapper.rs
+++ b/src/wrapper/standalone/wrapper.rs
@@ -121,6 +121,14 @@ struct WrapperWindowHandler {
     /// This is used to communicate with the wrapper from the audio thread and from within the
     /// baseview window handler on the GUI thread.
     gui_task_receiver: channel::Receiver<GuiTask>,
+
+    /// Set to true to signal the audio thread to stop processing. This is used to ensure the
+    /// audio thread stops before the window handler (and thus the editor) is dropped.
+    terminate_audio_thread: Arc<AtomicBool>,
+
+    /// Set to true by the audio thread when it has finished processing. Used to wait for the
+    /// audio thread to stop before allowing the window to close.
+    audio_thread_finished: Arc<AtomicBool>,
 }
 
 /// A message sent to the GUI thread.
@@ -146,7 +154,35 @@ impl WindowHandler for WrapperWindowHandler {
         }
     }
 
-    fn on_event(&mut self, _window: &mut Window, _event: baseview::Event) -> EventStatus {
+    fn on_event(&mut self, _window: &mut Window, event: baseview::Event) -> EventStatus {
+        // When the window is about to close, we need to stop the audio thread before the editor
+        // handle gets dropped. Otherwise there's a race condition where the audio thread might
+        // still be processing while the editor is being cleaned up, which can cause crashes
+        // (especially "Rust cannot catch foreign exceptions" errors on macOS).
+        if let baseview::Event::Window(baseview::WindowEvent::WillClose) = event {
+            // Signal the audio thread to stop
+            self.terminate_audio_thread.store(true, Ordering::SeqCst);
+
+            // Wait for the audio thread to finish processing. We use a spin-wait with a small
+            // sleep to avoid busy-waiting while still being responsive. The audio thread should
+            // exit quickly once it sees the terminate signal.
+            //
+            // We use a timeout to prevent hanging forever if something goes wrong. The audio
+            // thread should typically exit within a few hundred milliseconds at most.
+            const MAX_WAIT_MS: u32 = 5000;
+            let mut waited_ms = 0;
+            while !self.audio_thread_finished.load(Ordering::SeqCst) && waited_ms < MAX_WAIT_MS {
+                std::thread::sleep(std::time::Duration::from_millis(1));
+                waited_ms += 1;
+            }
+
+            if waited_ms >= MAX_WAIT_MS {
+                nih_log!(
+                    "Warning: Timed out waiting for audio thread to finish during window close"
+                );
+            }
+        }
+
         EventStatus::Ignored
     }
 }
@@ -314,10 +350,19 @@ impl<P: Plugin, B: Backend<P>> Wrapper<P, B> {
         // We'll spawn a separate thread to handle IO and to process audio. This audio thread should
         // terminate together with this function.
         let terminate_audio_thread = Arc::new(AtomicBool::new(false));
+        // This flag is set by the audio thread when it has finished processing. This is used by
+        // the window handler to wait for the audio thread to stop before allowing the window to
+        // close, preventing race conditions during cleanup.
+        let audio_thread_finished = Arc::new(AtomicBool::new(false));
         let audio_thread = {
             let this = self.clone();
             let terminate_audio_thread = terminate_audio_thread.clone();
-            thread::spawn(move || this.run_audio_thread(terminate_audio_thread, gui_task_sender))
+            let audio_thread_finished = audio_thread_finished.clone();
+            thread::spawn(move || {
+                this.run_audio_thread(terminate_audio_thread, gui_task_sender);
+                // Signal that we're done processing so the window handler can proceed with cleanup
+                audio_thread_finished.store(true, Ordering::SeqCst);
+            })
         };
 
         match self.editor.borrow().clone() {
@@ -334,6 +379,9 @@ impl<P: Plugin, B: Backend<P>> Wrapper<P, B> {
                 };
 
                 let (width, height) = editor.lock().size();
+                // Clone the flags to pass into the window handler closure
+                let terminate_audio_thread_for_handler = terminate_audio_thread.clone();
+                let audio_thread_finished_for_handler = audio_thread_finished.clone();
                 Window::open_blocking(
                     WindowOpenOptions {
                         title: String::from(P::NAME),
@@ -370,6 +418,8 @@ impl<P: Plugin, B: Backend<P>> Wrapper<P, B> {
                         WrapperWindowHandler {
                             _editor_handle: editor_handle,
                             gui_task_receiver,
+                            terminate_audio_thread: terminate_audio_thread_for_handler,
+                            audio_thread_finished: audio_thread_finished_for_handler,
                         }
                     },
                 )
@@ -382,6 +432,9 @@ impl<P: Plugin, B: Backend<P>> Wrapper<P, B> {
             }
         }
 
+        // NOTE: When using the GUI, the window handler already sets this flag and waits for the
+        // audio thread to finish in `on_event(WillClose)`. This call is still needed for the
+        // non-GUI case and as an extra safety net.
         terminate_audio_thread.store(true, Ordering::SeqCst);
         audio_thread.join().unwrap();
 


### PR DESCRIPTION
## Summary

- Fix race condition when closing standalone GUI window that caused crashes with "Rust cannot catch foreign exceptions" errors on macOS
- Update baseview to latest revision which includes a null pointer fix for `become_first_responder` on macOS (PR RustAudio/baseview#204)

## Problem

When closing the standalone app via the GUI (Cmd+Q or clicking X on macOS), there was a race condition where:
1. `Window::open_blocking()` returns and the `WrapperWindowHandler` is dropped
2. This drops `_editor_handle`, starting editor cleanup
3. Only AFTER that do we signal the audio thread to stop
4. The audio thread may still be accessing shared resources during cleanup, causing the crash

## Solution

Handle `WindowEvent::WillClose` in `WrapperWindowHandler::on_event` to:
1. Signal the audio thread to terminate
2. Wait for the audio thread to finish (with 5s timeout)
3. Then allow the window to close and the editor to be dropped

Also updates baseview from rev `579130ec` to `237d323c` which fixes a separate macOS crash during window initialization with newer Rust versions (1.86+).

## Test plan

- [x] Build standalone plugin with GUI (e.g., `gain_gui_vizia`)
- [x] Run the standalone and verify window opens
- [x] Close via window X button - should exit cleanly
- [x] Verify no "foreign exceptions" crash

🤖 Generated with [Claude Code](https://claude.ai/code)