### PR TITLE
Adding support for updating plugin parameters presented to DAW when the GUI is closed and the update is initialed by MIDI message coming to the plugin

### DIFF
--- a/src/context/process.rs
+++ b/src/context/process.rs
@@ -1,7 +1,7 @@
 //! A context passed during the process function.
 
 use super::PluginApi;
-use crate::prelude::{Plugin, PluginNoteEvent};
+use crate::prelude::{ParamPtr, Plugin, PluginNoteEvent};
 
 /// Contains both context data and callbacks the plugin can use during processing. Most notably this
 /// is how a plugin sends and receives note events, gets transport information, and accesses
@@ -92,10 +92,11 @@ pub trait ProcessContext<P: Plugin> {
     /// monophonic modulation when dropping the capacity down to 1.
     fn set_current_voice_capacity(&self, capacity: u32);
 
-    // TODO: Add this, this works similar to [GuiContext::set_parameter] but it adds the parameter
-    //       change to a queue (or directly to the VST3 plugin's parameter output queues) instead of
-    //       using main thread host automation (and all the locks involved there).
-    // fn set_parameter<P: Param>(&self, param: &P, value: P::Plain);
+    /// Notify the host of a parameter change from the audio thread using a normalized value.
+    ///
+    /// This should be realtime-safe and value-only (no gesture semantics). The plugin is still
+    /// responsible for updating the actual parameter storage.
+    fn set_parameter_normalized(&self, param: ParamPtr, normalized: f32);
 }
 
 /// Information about the plugin's transport. Depending on the plugin API and the host not all

--- a/src/wrapper/clap/context.rs
+++ b/src/wrapper/clap/context.rs
@@ -127,6 +127,28 @@ impl<P: ClapPlugin> ProcessContext<P> for WrapperProcessContext<'_, P> {
     fn set_current_voice_capacity(&self, capacity: u32) {
         self.wrapper.set_current_voice_capacity(capacity)
     }
+
+    fn set_parameter_normalized(&self, param: ParamPtr, normalized: f32) {
+        match self.wrapper.param_ptr_to_hash.get(&param) {
+            Some(hash) => {
+                let step_count = unsafe { param.step_count().unwrap_or(1) } as f64;
+                let clap_plain_value = normalized as f64 * step_count;
+                let success = self
+                    .wrapper
+                    .queue_parameter_event(OutputParamEvent::SetValue {
+                        param_hash: *hash,
+                        clap_plain_value,
+                    });
+
+                nih_debug_assert!(
+                    success,
+                    "Parameter output event queue was full, parameter change will not be sent to \
+                     the host"
+                );
+            }
+            None => nih_debug_assert_failure!("Unknown parameter: {:?}", param),
+        }
+    }
 }
 
 impl<P: ClapPlugin> GuiContext for WrapperGuiContext<P> {

--- a/src/wrapper/standalone/context.rs
+++ b/src/wrapper/standalone/context.rs
@@ -52,6 +52,10 @@ impl<P: Plugin, B: Backend<P>> InitContext<P> for WrapperInitContext<'_, P, B> {
     fn set_current_voice_capacity(&self, _capacity: u32) {
         // This is only supported by CLAP
     }
+
+    fn set_parameter_normalized(&self, param: ParamPtr, normalized: f32) {
+        self.wrapper.set_parameter(param, normalized);
+    }
 }
 
 impl<P: Plugin, B: Backend<P>> ProcessContext<P> for WrapperProcessContext<'_, P, B> {

--- a/src/wrapper/vst3/context.rs
+++ b/src/wrapper/vst3/context.rs
@@ -10,7 +10,7 @@ use crate::prelude::{
     Transport, Vst3Plugin,
 };
 
-use super::inner::{Task, WrapperInner};
+use super::inner::{OutputParamChange, Task, WrapperInner};
 
 /// An [`InitContext`] implementation for the wrapper.
 ///
@@ -111,6 +111,28 @@ impl<P: Vst3Plugin> ProcessContext<P> for WrapperProcessContext<'_, P> {
 
     fn set_latency_samples(&self, samples: u32) {
         self.inner.set_latency_samples(samples)
+    }
+
+    fn set_parameter_normalized(&self, param: ParamPtr, normalized: f32) {
+        match self.inner.param_ptr_to_hash.get(&param) {
+            Some(hash) => {
+                let success = self
+                    .inner
+                    .output_parameter_changes
+                    .push(OutputParamChange {
+                        param_hash: *hash,
+                        normalized,
+                    })
+                    .is_ok();
+
+                nih_debug_assert!(
+                    success,
+                    "Output parameter change queue was full, parameter change will not be sent \
+                     to the host"
+                );
+            }
+            None => nih_debug_assert_failure!("Unknown parameter: {:?}", param),
+        }
     }
 
     fn set_current_voice_capacity(&self, _capacity: u32) {

--- a/src/wrapper/vst3/inner.rs
+++ b/src/wrapper/vst3/inner.rs
@@ -1,6 +1,7 @@
 use atomic_refcell::AtomicRefCell;
 use crossbeam::atomic::AtomicCell;
 use crossbeam::channel::{self, SendTimeoutError};
+use crossbeam::queue::ArrayQueue;
 use parking_lot::{Mutex, RwLock};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
@@ -23,6 +24,14 @@ use crate::util::permit_alloc;
 use crate::wrapper::state::{self, PluginState};
 use crate::wrapper::util::buffer_management::BufferManager;
 use crate::wrapper::util::{hash_param_id, process_wrapper};
+
+const OUTPUT_PARAM_QUEUE_CAPACITY: usize = 2048;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct OutputParamChange {
+    pub param_hash: u32,
+    pub normalized: f32,
+}
 
 /// The actual wrapper bits. We need this as an `Arc<T>` so we can safely use our event loop API.
 /// Since we can't combine that with VST3's interior reference counting this just has to be moved to
@@ -92,6 +101,8 @@ pub(crate) struct WrapperInner<P: Vst3Plugin> {
     /// Stores any events the plugin has output during the current processing cycle, analogous to
     /// `input_events`.
     pub output_events: AtomicRefCell<VecDeque<PluginNoteEvent<P>>>,
+    /// Realtime-safe output parameter changes sent from the audio thread.
+    pub output_parameter_changes: ArrayQueue<OutputParamChange>,
     /// VST3 has several useful predefined note expressions, but for some reason they are the only
     /// note event type that don't have MIDI note ID and channel fields. So we need to keep track of
     /// the most recent VST3 note IDs we've seen, and then map those back to MIDI note IDs and
@@ -307,6 +318,7 @@ impl<P: Vst3Plugin> WrapperInner<P> {
             )),
             input_events: AtomicRefCell::new(VecDeque::with_capacity(1024)),
             output_events: AtomicRefCell::new(VecDeque::with_capacity(1024)),
+            output_parameter_changes: ArrayQueue::new(OUTPUT_PARAM_QUEUE_CAPACITY),
             note_expression_controller: AtomicRefCell::new(NoteExpressionController::default()),
             process_events: AtomicRefCell::new(Vec::with_capacity(4096)),
             updated_state_sender,

--- a/src/wrapper/vst3/wrapper.rs
+++ b/src/wrapper/vst3/wrapper.rs
@@ -1636,6 +1636,32 @@ impl<P: Vst3Plugin> IAudioProcessor for Wrapper<P> {
                     }
                 }
 
+                if let Some(param_changes) = data.output_param_changes.upgrade() {
+                    let sample_offset = clamp_output_event_timing(
+                        block_start as u32,
+                        total_buffer_len as u32,
+                    ) as i32;
+                    while let Some(change) = self.inner.output_parameter_changes.pop() {
+                        let param_hash = change.param_hash;
+                        let mut queue_index = 0;
+                        let mut point_index = 0;
+                        if let Some(param_queue) = unsafe {
+                            param_changes
+                                .add_parameter_data(&param_hash as *const u32, &mut queue_index)
+                                .upgrade()
+                        } {
+                            let result = unsafe {
+                                param_queue.add_point(
+                                    sample_offset,
+                                    change.normalized as f64,
+                                    &mut point_index,
+                                )
+                            };
+                            nih_debug_assert_eq!(result, kResultOk);
+                        }
+                    }
+                }
+
                 // If our block ends at the end of the buffer then that means there are no more
                 // unprocessed (parameter) events. If there are more events, we'll just keep going
                 // through this process until we've processed the entire buffer.


### PR DESCRIPTION
Hello,
   the PR addresses the following scenario:

- there is a plugin written in nih_plug
- the plugin serves as a control plugin for hardware synth, providing the musicians (user) with named parameters and shielding them from device-specific MIDI implementation (which CCs, NRPNs, etc. to send)
- the plugin also reacts to the midi messages from the hardware synth, updating its parameters in the GUI and in the DAW (for automation, for example)

The problem:
When the UI is closed and the hardware synth sends a MIDI message, internally in the plugin, the parameter values is updated, however, the DAW is not notified about the parameter change.

Solution:
The PR adds the functionality to update the plugin parameter values presented to the DAW in reaction to MIDI messages even when the plugin's UI is closed.