### PR TITLE
Feature/track context info

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -5,6 +5,7 @@ use std::fmt::Display;
 pub mod gui;
 pub mod init;
 pub mod process;
+pub mod track_info;
 
 // Contexts for more plugin-API specific features
 pub mod remote_controls;

--- a/src/context/gui.rs
+++ b/src/context/gui.rs
@@ -2,6 +2,7 @@
 
 use std::sync::Arc;
 
+use super::track_info::TrackInfo;
 use super::PluginApi;
 use crate::prelude::{Param, ParamPtr, Plugin, PluginState};
 
@@ -63,6 +64,11 @@ pub trait GuiContext: Send + Sync + 'static {
     /// host. If the plugin is currently processing audio, then the parameter values will be
     /// restored at the end of the current processing cycle.
     fn set_state(&self, state: PluginState);
+
+    /// Get information about the track the plugin is on. Not all hosts support this, and the
+    /// information may not be available until the host provides it. Returns `None` if the host
+    /// does not provide track information.
+    fn track_info(&self) -> Option<TrackInfo>;
 }
 
 /// An way to run background tasks from the plugin's GUI, equivalent to the

--- a/src/context/init.rs
+++ b/src/context/init.rs
@@ -1,5 +1,6 @@
 //! A context passed during plugin initialization.
 
+use super::track_info::TrackInfo;
 use super::PluginApi;
 use crate::prelude::Plugin;
 
@@ -34,4 +35,9 @@ pub trait InitContext<P: Plugin> {
     /// runtime allows the host to better optimize polyphonic modulation, or to switch to strictly
     /// monophonic modulation when dropping the capacity down to 1.
     fn set_current_voice_capacity(&self, capacity: u32);
+
+    /// Get information about the track the plugin is on. Not all hosts support this, and the
+    /// information may not be available until the host provides it. Returns `None` if the host
+    /// does not provide track information.
+    fn track_info(&self) -> Option<TrackInfo>;
 }

--- a/src/context/process.rs
+++ b/src/context/process.rs
@@ -1,5 +1,6 @@
 //! A context passed during the process function.
 
+use super::track_info::TrackInfo;
 use super::PluginApi;
 use crate::prelude::{Plugin, PluginNoteEvent};
 
@@ -39,6 +40,11 @@ pub trait ProcessContext<P: Plugin> {
 
     /// Get information about the current transport position and status.
     fn transport(&self) -> &Transport;
+
+    /// Get information about the track the plugin is on. Not all hosts support this, and the
+    /// information may not be available until the host provides it. Returns `None` if the host
+    /// does not provide track information.
+    fn track_info(&self) -> Option<TrackInfo>;
 
     /// Returns the next note event, if there is one. Use
     /// [`NoteEvent::timing()`][crate::prelude::NoteEvent::timing()] to get the event's timing

--- a/src/context/track_info.rs
+++ b/src/context/track_info.rs
@@ -7,7 +7,7 @@
 /// [`InitContext`][super::init::InitContext],
 /// [`ProcessContext`][super::process::ProcessContext], and
 /// [`GuiContext`][super::gui::GuiContext].
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct TrackInfo {
     /// The name of the track, if available.
     pub name: Option<String>,

--- a/src/context/track_info.rs
+++ b/src/context/track_info.rs
@@ -1,0 +1,43 @@
+//! Information about the track/channel the plugin is inserted on.
+
+/// Information about the track the plugin is on. Not all hosts and plugin APIs support all fields,
+/// so most of them are optional.
+///
+/// This is queried from the host and may change at any time. It can be accessed from
+/// [`InitContext`][super::init::InitContext],
+/// [`ProcessContext`][super::process::ProcessContext], and
+/// [`GuiContext`][super::gui::GuiContext].
+#[derive(Debug, Clone, PartialEq)]
+pub struct TrackInfo {
+    /// The name of the track, if available.
+    pub name: Option<String>,
+    /// The color assigned to the track, if available.
+    pub color: Option<TrackColor>,
+    /// The number of audio channels on the track, if available.
+    pub audio_channel_count: Option<u32>,
+    /// The type of track the plugin is on.
+    pub track_type: TrackType,
+}
+
+/// An RGBA color value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TrackColor {
+    pub red: u8,
+    pub green: u8,
+    pub blue: u8,
+    pub alpha: u8,
+}
+
+/// The type of track the plugin is inserted on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum TrackType {
+    /// A regular track.
+    #[default]
+    Regular,
+    /// A return/FX track.
+    Return,
+    /// A bus/group track.
+    Bus,
+    /// The master/main output track.
+    Master,
+}

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -23,6 +23,7 @@ pub use crate::context::process::{ProcessContext, Transport};
 pub use crate::context::remote_controls::{
     RemoteControlsContext, RemoteControlsPage, RemoteControlsSection,
 };
+pub use crate::context::track_info::{TrackColor, TrackInfo, TrackType};
 pub use crate::context::PluginApi;
 // This also includes the derive macro
 pub use crate::editor::{Editor, ParentWindowHandle};

--- a/src/wrapper/clap/context.rs
+++ b/src/wrapper/clap/context.rs
@@ -1,7 +1,5 @@
 use atomic_refcell::AtomicRefMut;
-use clap_sys::ext::remote_controls::{
-    clap_remote_controls_page, CLAP_REMOTE_CONTROLS_COUNT,
-};
+use clap_sys::ext::remote_controls::{clap_remote_controls_page, CLAP_REMOTE_CONTROLS_COUNT};
 use clap_sys::id::{clap_id, CLAP_INVALID_ID};
 use clap_sys::string_sizes::CLAP_NAME_SIZE;
 use std::cell::Cell;
@@ -9,6 +7,7 @@ use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 
 use super::wrapper::{OutputParamEvent, Task, Wrapper};
+use crate::context::track_info::TrackInfo;
 use crate::event_loop::EventLoop;
 use crate::prelude::{
     ClapPlugin, GuiContext, InitContext, ParamPtr, PluginApi, PluginNoteEvent, ProcessContext,
@@ -90,6 +89,10 @@ impl<P: ClapPlugin> InitContext<P> for WrapperInitContext<'_, P> {
     fn set_current_voice_capacity(&self, capacity: u32) {
         self.wrapper.set_current_voice_capacity(capacity)
     }
+
+    fn track_info(&self) -> Option<TrackInfo> {
+        self.wrapper.get_track_info()
+    }
 }
 
 impl<P: ClapPlugin> ProcessContext<P> for WrapperProcessContext<'_, P> {
@@ -110,6 +113,10 @@ impl<P: ClapPlugin> ProcessContext<P> for WrapperProcessContext<'_, P> {
     #[inline]
     fn transport(&self) -> &Transport {
         &self.transport
+    }
+
+    fn track_info(&self) -> Option<TrackInfo> {
+        self.wrapper.get_track_info()
     }
 
     fn next_event(&mut self) -> Option<PluginNoteEvent<P>> {
@@ -239,6 +246,10 @@ impl<P: ClapPlugin> GuiContext for WrapperGuiContext<P> {
 
     fn set_state(&self, state: crate::wrapper::state::PluginState) {
         self.wrapper.set_state_object_from_gui(state)
+    }
+
+    fn track_info(&self) -> Option<TrackInfo> {
+        self.wrapper.get_track_info()
     }
 }
 

--- a/src/wrapper/clap/wrapper.rs
+++ b/src/wrapper/clap/wrapper.rs
@@ -3285,7 +3285,7 @@ impl<P: ClapPlugin> Wrapper<P> {
             };
 
             let audio_channel_count = if info.flags & CLAP_TRACK_INFO_HAS_AUDIO_CHANNEL != 0 {
-                Some(info.audio_channel_count as u32)
+                u32::try_from(info.audio_channel_count).ok()
             } else {
                 None
             };

--- a/src/wrapper/clap/wrapper.rs
+++ b/src/wrapper/clap/wrapper.rs
@@ -22,9 +22,6 @@ use clap_sys::ext::audio_ports::{
 use clap_sys::ext::audio_ports_config::{
     clap_audio_ports_config, clap_plugin_audio_ports_config, CLAP_EXT_AUDIO_PORTS_CONFIG,
 };
-use clap_sys::ext::remote_controls::{
-    clap_plugin_remote_controls, clap_remote_controls_page, CLAP_EXT_REMOTE_CONTROLS,
-};
 use clap_sys::ext::gui::{
     clap_gui_resize_hints, clap_host_gui, clap_plugin_gui, clap_window, CLAP_EXT_GUI,
     CLAP_WINDOW_API_COCOA, CLAP_WINDOW_API_WIN32, CLAP_WINDOW_API_X11,
@@ -40,6 +37,9 @@ use clap_sys::ext::params::{
     CLAP_PARAM_IS_MODULATABLE, CLAP_PARAM_IS_MODULATABLE_PER_NOTE_ID, CLAP_PARAM_IS_READONLY,
     CLAP_PARAM_IS_STEPPED, CLAP_PARAM_RESCAN_VALUES,
 };
+use clap_sys::ext::remote_controls::{
+    clap_plugin_remote_controls, clap_remote_controls_page, CLAP_EXT_REMOTE_CONTROLS,
+};
 use clap_sys::ext::render::{
     clap_plugin_render, clap_plugin_render_mode, CLAP_EXT_RENDER, CLAP_RENDER_OFFLINE,
     CLAP_RENDER_REALTIME,
@@ -47,6 +47,12 @@ use clap_sys::ext::render::{
 use clap_sys::ext::state::{clap_plugin_state, CLAP_EXT_STATE};
 use clap_sys::ext::tail::{clap_plugin_tail, CLAP_EXT_TAIL};
 use clap_sys::ext::thread_check::{clap_host_thread_check, CLAP_EXT_THREAD_CHECK};
+use clap_sys::ext::track_info::{
+    clap_host_track_info, clap_plugin_track_info, CLAP_EXT_TRACK_INFO, CLAP_EXT_TRACK_INFO_COMPAT,
+    CLAP_TRACK_INFO_HAS_AUDIO_CHANNEL, CLAP_TRACK_INFO_HAS_TRACK_COLOR,
+    CLAP_TRACK_INFO_HAS_TRACK_NAME, CLAP_TRACK_INFO_IS_FOR_BUS, CLAP_TRACK_INFO_IS_FOR_MASTER,
+    CLAP_TRACK_INFO_IS_FOR_RETURN_TRACK,
+};
 use clap_sys::ext::voice_info::{
     clap_host_voice_info, clap_plugin_voice_info, clap_voice_info, CLAP_EXT_VOICE_INFO,
     CLAP_VOICE_INFO_SUPPORTS_OVERLAPPING_NOTES,
@@ -63,7 +69,7 @@ use clap_sys::stream::{clap_istream, clap_ostream};
 use crossbeam::atomic::AtomicCell;
 use crossbeam::channel::{self, SendTimeoutError};
 use crossbeam::queue::ArrayQueue;
-use parking_lot::Mutex;
+use parking_lot::{Mutex, RwLock};
 use std::any::Any;
 use std::borrow::Borrow;
 use std::collections::{HashMap, HashSet, VecDeque};
@@ -80,6 +86,7 @@ use std::time::Duration;
 use super::context::{WrapperGuiContext, WrapperInitContext, WrapperProcessContext};
 use super::descriptor::PluginDescriptor;
 use super::util::ClapPtr;
+use crate::context::track_info::{TrackColor, TrackInfo, TrackType};
 use crate::event_loop::{BackgroundThread, EventLoop, MainThreadExecutor, TASK_QUEUE_CAPACITY};
 use crate::midi::MidiResult;
 use crate::prelude::{
@@ -241,6 +248,11 @@ pub struct Wrapper<P: ClapPlugin> {
     /// of active voices using a context method called from the initialization or processing
     /// context. This defaults to the maximum number of voices.
     current_voice_capacity: AtomicU32,
+
+    clap_plugin_track_info: clap_plugin_track_info,
+    host_track_info: AtomicRefCell<Option<ClapPtr<clap_host_track_info>>>,
+    /// The current track information, as reported by the host through the track-info extension.
+    track_info: RwLock<Option<TrackInfo>>,
 
     /// A queue of tasks that still need to be performed. Because CLAP lets the plugin request a
     /// host callback directly, we don't need to use the OsEventLoop we use in our other plugin
@@ -680,6 +692,12 @@ impl<P: ClapPlugin> Wrapper<P> {
                     })
                     .unwrap_or(1),
             ),
+
+            clap_plugin_track_info: clap_plugin_track_info {
+                changed: Some(Self::ext_track_info_changed),
+            },
+            host_track_info: AtomicRefCell::new(None),
+            track_info: RwLock::new(None),
 
             tasks: ArrayQueue::new(TASK_QUEUE_CAPACITY),
             main_thread_id: thread::current().id(),
@@ -1855,6 +1873,18 @@ impl<P: ClapPlugin> Wrapper<P> {
             &wrapper.host_callback,
             CLAP_EXT_THREAD_CHECK,
         );
+        *wrapper.host_track_info.borrow_mut() = query_host_extension::<clap_host_track_info>(
+            &wrapper.host_callback,
+            CLAP_EXT_TRACK_INFO,
+        )
+        .or_else(|| {
+            query_host_extension::<clap_host_track_info>(
+                &wrapper.host_callback,
+                CLAP_EXT_TRACK_INFO_COMPAT,
+            )
+        });
+        // Fetch initial track info if available
+        wrapper.update_track_info();
 
         true
     }
@@ -2337,6 +2367,8 @@ impl<P: ClapPlugin> Wrapper<P> {
             &wrapper.clap_plugin_tail as *const _ as *const c_void
         } else if id == CLAP_EXT_VOICE_INFO && P::CLAP_POLY_MODULATION_CONFIG.is_some() {
             &wrapper.clap_plugin_voice_info as *const _ as *const c_void
+        } else if id == CLAP_EXT_TRACK_INFO || id == CLAP_EXT_TRACK_INFO_COMPAT {
+            &wrapper.clap_plugin_track_info as *const _ as *const c_void
         } else {
             nih_trace!("Host tried to query unknown extension {:?}", id);
             std::ptr::null()
@@ -3209,6 +3241,79 @@ impl<P: ClapPlugin> Wrapper<P> {
             }
             None => false,
         }
+    }
+
+    unsafe extern "C" fn ext_track_info_changed(plugin: *const clap_plugin) {
+        check_null_ptr!((), plugin, (*plugin).plugin_data);
+        let wrapper = &*((*plugin).plugin_data as *const Self);
+
+        wrapper.update_track_info();
+    }
+
+    /// Query the host for the current track information and store it.
+    fn update_track_info(&self) {
+        let host_track_info = self.host_track_info.borrow();
+        let host_track_info = match host_track_info.as_ref() {
+            Some(h) => h,
+            None => return,
+        };
+
+        let mut info = std::mem::MaybeUninit::uninit();
+        let success = unsafe {
+            clap_call! { host_track_info=>get(&*self.host_callback, info.as_mut_ptr()) }
+        };
+
+        if success {
+            let info = unsafe { info.assume_init() };
+
+            let name = if info.flags & CLAP_TRACK_INFO_HAS_TRACK_NAME != 0 {
+                let name_cstr = unsafe { CStr::from_ptr(info.name.as_ptr()) };
+                name_cstr.to_str().ok().map(|s| s.to_string())
+            } else {
+                None
+            };
+
+            let color = if info.flags & CLAP_TRACK_INFO_HAS_TRACK_COLOR != 0 {
+                Some(TrackColor {
+                    red: info.color.red,
+                    green: info.color.green,
+                    blue: info.color.blue,
+                    alpha: info.color.alpha,
+                })
+            } else {
+                None
+            };
+
+            let audio_channel_count = if info.flags & CLAP_TRACK_INFO_HAS_AUDIO_CHANNEL != 0 {
+                Some(info.audio_channel_count as u32)
+            } else {
+                None
+            };
+
+            let track_type = if info.flags & CLAP_TRACK_INFO_IS_FOR_MASTER != 0 {
+                TrackType::Master
+            } else if info.flags & CLAP_TRACK_INFO_IS_FOR_RETURN_TRACK != 0 {
+                TrackType::Return
+            } else if info.flags & CLAP_TRACK_INFO_IS_FOR_BUS != 0 {
+                TrackType::Bus
+            } else {
+                TrackType::Regular
+            };
+
+            *self.track_info.write() = Some(TrackInfo {
+                name,
+                color,
+                audio_channel_count,
+                track_type,
+            });
+        } else {
+            *self.track_info.write() = None;
+        }
+    }
+
+    /// Get the current track info, if available.
+    pub fn get_track_info(&self) -> Option<TrackInfo> {
+        self.track_info.read().clone()
     }
 }
 

--- a/src/wrapper/standalone/context.rs
+++ b/src/wrapper/standalone/context.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use super::backend::Backend;
 use super::wrapper::{Task, Wrapper};
+use crate::context::track_info::TrackInfo;
 use crate::prelude::{
     GuiContext, InitContext, ParamPtr, Plugin, PluginApi, PluginNoteEvent, ProcessContext,
     Transport,
@@ -52,6 +53,10 @@ impl<P: Plugin, B: Backend<P>> InitContext<P> for WrapperInitContext<'_, P, B> {
     fn set_current_voice_capacity(&self, _capacity: u32) {
         // This is only supported by CLAP
     }
+
+    fn track_info(&self) -> Option<TrackInfo> {
+        None
+    }
 }
 
 impl<P: Plugin, B: Backend<P>> ProcessContext<P> for WrapperProcessContext<'_, P, B> {
@@ -96,6 +101,10 @@ impl<P: Plugin, B: Backend<P>> ProcessContext<P> for WrapperProcessContext<'_, P
 
     fn set_current_voice_capacity(&self, _capacity: u32) {
         // This is only supported by CLAP
+    }
+
+    fn track_info(&self) -> Option<TrackInfo> {
+        None
     }
 }
 
@@ -158,5 +167,9 @@ impl<P: Plugin, B: Backend<P>> GuiContext for WrapperGuiContext<P, B> {
 
     fn set_state(&self, state: crate::wrapper::state::PluginState) {
         self.wrapper.set_state_object_from_gui(state)
+    }
+
+    fn track_info(&self) -> Option<TrackInfo> {
+        None
     }
 }

--- a/src/wrapper/vst3/context.rs
+++ b/src/wrapper/vst3/context.rs
@@ -5,6 +5,7 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use vst3_sys::vst::IComponentHandler;
 
+use crate::context::track_info::TrackInfo;
 use crate::prelude::{
     GuiContext, InitContext, ParamPtr, PluginApi, PluginNoteEvent, PluginState, ProcessContext,
     Transport, Vst3Plugin,
@@ -79,6 +80,10 @@ impl<P: Vst3Plugin> InitContext<P> for WrapperInitContext<'_, P> {
     fn set_current_voice_capacity(&self, _capacity: u32) {
         // This is only supported by CLAP
     }
+
+    fn track_info(&self) -> Option<TrackInfo> {
+        self.inner.get_track_info()
+    }
 }
 
 impl<P: Vst3Plugin> ProcessContext<P> for WrapperProcessContext<'_, P> {
@@ -99,6 +104,10 @@ impl<P: Vst3Plugin> ProcessContext<P> for WrapperProcessContext<'_, P> {
     #[inline]
     fn transport(&self) -> &Transport {
         &self.transport
+    }
+
+    fn track_info(&self) -> Option<TrackInfo> {
+        self.inner.get_track_info()
     }
 
     fn next_event(&mut self) -> Option<PluginNoteEvent<P>> {
@@ -227,5 +236,9 @@ impl<P: Vst3Plugin> GuiContext for WrapperGuiContext<P> {
 
     fn set_state(&self, state: PluginState) {
         self.inner.set_state_object_from_gui(state)
+    }
+
+    fn track_info(&self) -> Option<TrackInfo> {
+        self.inner.get_track_info()
     }
 }

--- a/src/wrapper/vst3/inner.rs
+++ b/src/wrapper/vst3/inner.rs
@@ -1,3 +1,4 @@
+use crate::context::track_info::TrackInfo;
 use atomic_refcell::AtomicRefCell;
 use crossbeam::atomic::AtomicCell;
 use crossbeam::channel::{self, SendTimeoutError};
@@ -137,6 +138,9 @@ pub(crate) struct WrapperInner<P: Vst3Plugin> {
     /// having to add a setter function to the parameter (or even worse, have it be completely
     /// untyped).
     pub param_ptr_to_hash: HashMap<ParamPtr, u32>,
+
+    /// The current track information, as reported by the host through `IInfoListener`.
+    pub track_info: RwLock<Option<TrackInfo>>,
 }
 
 /// Tasks that can be sent from the plugin to be executed on the main thread in a non-blocking
@@ -318,6 +322,8 @@ impl<P: Vst3Plugin> WrapperInner<P> {
             param_units,
             param_id_to_hash,
             param_ptr_to_hash,
+
+            track_info: RwLock::new(None),
         });
 
         // FIXME: Right now this is safe, but if we are going to have a singleton main thread queue
@@ -428,6 +434,11 @@ impl<P: Vst3Plugin> WrapperInner<P> {
             .get(&param)
             .and_then(|hash| self.param_id_by_hash.get(hash))
             .map(|s| s.as_str())
+    }
+
+    /// Get the current track info, if available.
+    pub fn get_track_info(&self) -> Option<TrackInfo> {
+        self.track_info.read().clone()
     }
 
     /// Convenience function for setting a value for a parameter as triggered by a VST3 parameter

--- a/src/wrapper/vst3/wrapper.rs
+++ b/src/wrapper/vst3/wrapper.rs
@@ -27,7 +27,7 @@ use super::util::{
 };
 use super::util::{VST3_MIDI_CHANNELS, VST3_MIDI_PARAMS_END};
 use super::view::WrapperView;
-use crate::context::track_info::{TrackColor, TrackInfo};
+use crate::context::track_info::{TrackColor, TrackInfo, TrackType};
 use crate::prelude::{
     AuxiliaryBuffers, BufferConfig, MidiConfig, NoteEvent, ParamFlags, ProcessMode, ProcessStatus,
     SysExMessage, Transport, Vst3Plugin,
@@ -1921,6 +1921,8 @@ impl<P: Vst3Plugin> IInfoListener for Wrapper<P> {
             name_buf.len() as u32,
         ) == kResultOk
         {
+            // Ensure null termination in case a buggy host fills the entire buffer
+            name_buf[name_buf.len() - 1] = 0;
             U16CStr::from_ptr_str(name_buf.as_ptr() as *const u16)
                 .to_string()
                 .ok()
@@ -1958,7 +1960,7 @@ impl<P: Vst3Plugin> IInfoListener for Wrapper<P> {
                 color,
                 // VST3's IInfoListener doesn't provide channel count or track type
                 audio_channel_count: None,
-                track_type: crate::context::track_info::TrackType::Regular,
+                track_type: TrackType::Regular,
             });
         }
 

--- a/src/wrapper/vst3/wrapper.rs
+++ b/src/wrapper/vst3/wrapper.rs
@@ -10,11 +10,12 @@ use vst3_sys::base::{kInvalidArgument, kNoInterface, kResultFalse, kResultOk, tr
 use vst3_sys::base::{IBStream, IPluginBase};
 use vst3_sys::utils::SharedVstPtr;
 use vst3_sys::vst::{
-    kNoParamId, kNoParentUnitId, kNoProgramListId, kRootUnitId, Event, EventTypes, IAudioProcessor,
-    IComponent, IEditController, IEventList, IMidiMapping, INoteExpressionController,
-    IParamValueQueue, IParameterChanges, IProcessContextRequirements, IUnitInfo,
-    LegacyMidiCCOutEvent, NoteExpressionTypeInfo, NoteExpressionValueDescription, NoteOffEvent,
-    NoteOnEvent, ParameterFlags, PolyPressureEvent, ProgramListInfo, TChar, UnitInfo,
+    kChannelColorKey, kChannelNameKey, kNoParamId, kNoParentUnitId, kNoProgramListId, kRootUnitId,
+    Event, EventTypes, IAttributeList, IAudioProcessor, IComponent, IEditController, IEventList,
+    IInfoListener, IMidiMapping, INoteExpressionController, IParamValueQueue, IParameterChanges,
+    IProcessContextRequirements, IUnitInfo, LegacyMidiCCOutEvent, NoteExpressionTypeInfo,
+    NoteExpressionValueDescription, NoteOffEvent, NoteOnEvent, ParameterFlags, PolyPressureEvent,
+    ProgramListInfo, TChar, UnitInfo,
 };
 use vst3_sys::VST3;
 use widestring::U16CStr;
@@ -26,6 +27,7 @@ use super::util::{
 };
 use super::util::{VST3_MIDI_CHANNELS, VST3_MIDI_PARAMS_END};
 use super::view::WrapperView;
+use crate::context::track_info::{TrackColor, TrackInfo};
 use crate::prelude::{
     AuxiliaryBuffers, BufferConfig, MidiConfig, NoteEvent, ParamFlags, ProcessMode, ProcessStatus,
     SysExMessage, Transport, Vst3Plugin,
@@ -45,7 +47,8 @@ use vst3_sys as vst3_com;
     IMidiMapping,
     INoteExpressionController,
     IProcessContextRequirements,
-    IUnitInfo
+    IUnitInfo,
+    IInfoListener
 ))]
 pub struct Wrapper<P: Vst3Plugin> {
     inner: Arc<WrapperInner<P>>,
@@ -1891,5 +1894,74 @@ impl<P: Vst3Plugin> IUnitInfo for Wrapper<P> {
         _data: SharedVstPtr<dyn IBStream>,
     ) -> tresult {
         kInvalidArgument
+    }
+}
+
+impl<P: Vst3Plugin> IInfoListener for Wrapper<P> {
+    unsafe fn set_channel_context_infos(&self, list: *mut c_void) -> tresult {
+        if list.is_null() {
+            *self.inner.track_info.write() = None;
+            return kResultOk;
+        }
+
+        // The list parameter is an IAttributeList* passed as c_void*. In the vst3-sys COM
+        // model, an interface pointer is `*mut *mut VTable`, so we cast accordingly.
+        let attr_list: vst3_sys::VstPtr<dyn IAttributeList> = match vst3_sys::VstPtr::shared(
+            list as *mut *mut <dyn IAttributeList as vst3_sys::ComInterface>::VTable,
+        ) {
+            Some(ptr) => ptr,
+            None => return kResultOk,
+        };
+
+        // Read channel name
+        let mut name_buf = [0i16; 128];
+        let name = if attr_list.get_string(
+            kChannelNameKey,
+            name_buf.as_mut_ptr(),
+            name_buf.len() as u32,
+        ) == kResultOk
+        {
+            U16CStr::from_ptr_str(name_buf.as_ptr() as *const u16)
+                .to_string()
+                .ok()
+        } else {
+            None
+        };
+
+        // Read channel color (ColorSpec is a u32 packed as ARGB)
+        let mut color_value: i64 = 0;
+        let color = if attr_list.get_int(kChannelColorKey, &mut color_value) == kResultOk {
+            let cs = color_value as u32;
+            Some(TrackColor {
+                alpha: ((cs >> 24) & 0xFF) as u8,
+                red: ((cs >> 16) & 0xFF) as u8,
+                green: ((cs >> 8) & 0xFF) as u8,
+                blue: (cs & 0xFF) as u8,
+            })
+        } else {
+            None
+        };
+
+        // Merge with existing track info rather than replacing, since some hosts (e.g.
+        // Ableton Live) may send partial updates with name and color in separate calls
+        let mut track_info = self.inner.track_info.write();
+        if let Some(existing) = track_info.as_mut() {
+            if name.is_some() {
+                existing.name = name;
+            }
+            if color.is_some() {
+                existing.color = color;
+            }
+        } else {
+            *track_info = Some(TrackInfo {
+                name,
+                color,
+                // VST3's IInfoListener doesn't provide channel count or track type
+                audio_channel_count: None,
+                track_type: crate::context::track_info::TrackType::Regular,
+            });
+        }
+
+        kResultOk
     }
 }


### PR DESCRIPTION
  ## Summary

This PR adds a `TrackInfo` API that exposes track name, color, channel count, and track type to plugins. Implements the backing host integrations for both CLAP (`clap.track-info` extension) and VST3 (`IInfoListener::setChannelContextInfos`).

Resolves #119.

## New API

```rust
// Available from InitContext, ProcessContext, and GuiContext:
if let Some(info) = context.track_info() {
    let name = info.name.as_deref().unwrap_or("unnamed");
    let color = info.color;                // Option<TrackColor>
    let channels = info.audio_channel_count; // Option<u32> (CLAP only)
    let track_type = info.track_type;      // TrackType enum (CLAP only)
}
```

New types (re-exported via `nih_plug::prelude`)

- `TrackInfo` — name, color, channel count, track type
- `TrackColor` — RGBA (u8 per channel)
- `TrackType` — Regular | Return | Bus | Master

### Implementation details

#### CLAP

  - Uses `clap.track-info` extension with `CLAP_EXT_TRACK_INFO_COMPAT` fallback for older hosts
  - Pull model: plugin queries host via `clap_host_track_info::get()`
  - changed callback triggers re-query
  - Provides all fields including channel count and track type
  - Safe u`32::try_from()` cast for `audio_channel_count` (guards against negative sentinels)

#### VST3

  - Implements `IInfoListener` (added to `#[VST3(implements(...))]`)
  - Push model: host calls `set_channel_context_infos(IAttributeList*)`
  - Reads `kChannelNameKey` (UTF-16) and `kChannelColorKey` (ARGB packed `u32`)
  - Merges partial updates rather than replacing — Ableton Live sends name and color in separate calls
  - Cannot provide channel count or track type (VST3 API limitation)
  - Null-termination guard on name buffer for defensive hardening

#### Standalone

- Returns None for all contexts (no host to query)

## Host compatibility

Verified working with REAPER (VST3 track name confirmed).
VST3 `IInfoListener` known to be supported by Cubase, Nuendo, REAPER, Ableton Live, Bitwig, Studio One, FL Studio, Digital Performer, and Cakewalk.

## Important note

Track info arrives after `initialize()`. Both VST3 and CLAP hosts push/provide track info after the plugin is fully set up. Plugins should query from `process()` or the GUI, not rely on it during `init`.

## Test plan

- `cargo build` (default features)
- `cargo build --no-default-features`
- `cargo test --features "standalone,zstd" `— all tests pass
- `cargo clippy` — no new warnings
- Manual: REAPER VST3 shows track name "Drums"
- Manual: REAPER CLAP shows track info