### PR TITLE
Finish switching from vst3-sys to vst3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1197,6 +1197,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "com-scrape-types"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ce183b975b8fc736a20919c4002717255fbd867df575c792aeefa9a56a73ad0"
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3583,7 +3589,7 @@ dependencies = [
  "rtrb",
  "serde",
  "serde_json",
- "vst3-sys",
+ "vst3",
  "widestring",
  "windows 0.44.0",
  "zstd",
@@ -6035,40 +6041,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "vst3-com"
-version = "0.1.0"
-source = "git+https://github.com/robbert-vdh/vst3-sys.git?branch=fix/drop-box-from-raw#b3ff4d775940f5b476b9d1cca02a90e07e1922a2"
+name = "vst3"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31e3fe7a6f028ded8c5a9984cf283319e6dc63572c9b71da1d4ee9d71d3b6bf"
 dependencies = [
- "vst3-com-macros",
-]
-
-[[package]]
-name = "vst3-com-macros"
-version = "0.2.0"
-source = "git+https://github.com/robbert-vdh/vst3-sys.git?branch=fix/drop-box-from-raw#b3ff4d775940f5b476b9d1cca02a90e07e1922a2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "vst3-com-macros-support",
-]
-
-[[package]]
-name = "vst3-com-macros-support"
-version = "0.2.0"
-source = "git+https://github.com/robbert-vdh/vst3-sys.git?branch=fix/drop-box-from-raw#b3ff4d775940f5b476b9d1cca02a90e07e1922a2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "vst3-sys"
-version = "0.1.0"
-source = "git+https://github.com/robbert-vdh/vst3-sys.git?branch=fix/drop-box-from-raw#b3ff4d775940f5b476b9d1cca02a90e07e1922a2"
-dependencies = [
- "vst3-com",
+ "com-scrape-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ standalone = ["dep:baseview", "dep:clap", "dep:cpal", "dep:jack", "dep:midir", "
 # exists mostly for GPL-compliance reasons, since even if you don't use the VST3
 # wrapper you might otherwise still include a couple (unused) symbols from the
 # `vst3-sys` crate.
-vst3 = ["dep:vst3-sys"]
+vst3 = ["dep:vst3"]
 # Add adapters to the Buffer object for reading the channel data to and from
 # `std::simd` vectors. Requires a nightly compiler.
 simd = []
@@ -112,7 +112,7 @@ midir = { version = "0.9.1", optional = true }
 rtrb = { version = "0.2.2", optional = true }
 
 # Used for the `vst3` feature
-vst3-sys = { git = "https://github.com/robbert-vdh/vst3-sys.git", branch = "fix/drop-box-from-raw", optional = true }
+vst3 = { version = "0.3.0", optional = true }
 
 # Used for the `zstd` feature
 zstd = { version = "0.12.3", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ standalone = ["dep:baseview", "dep:clap", "dep:cpal", "dep:jack", "dep:midir", "
 # Enables the `nih_export_vst3!()` macro. Enabled by default. This feature
 # exists mostly for GPL-compliance reasons, since even if you don't use the VST3
 # wrapper you might otherwise still include a couple (unused) symbols from the
-# `vst3-sys` crate.
+# `vst3` crate.
 vst3 = ["dep:vst3"]
 # Add adapters to the Buffer object for reading the channel data to and from
 # `std::simd` vectors. Requires a nightly compiler.

--- a/README.md
+++ b/README.md
@@ -226,12 +226,7 @@ examples.
 ## Licensing
 
 The framework, its libraries, and the example plugins in `plugins/examples/` are
-all licensed under the [ISC license](https://www.isc.org/licenses/). However,
-the [VST3 bindings](https://github.com/RustAudio/vst3-sys) used by
-`nih_export_vst3!()` are licensed under the GPLv3 license. This means that
-unless you replace these bindings with your own bindings made from scratch, any
-VST3 plugins built with NIH-plug need to be able to comply with the terms of the
-GPLv3 license.
+all licensed under the [ISC license](https://www.isc.org/licenses/).
 
 The other plugins in the `plugins/` directory may be licensed under the GPLv3
 license. Check the plugin's `Cargo.toml` file for more information.

--- a/src/buffer/blocks.rs
+++ b/src/buffer/blocks.rs
@@ -3,7 +3,7 @@
 use std::marker::PhantomData;
 
 #[cfg(feature = "simd")]
-use std::simd::{LaneCount, Simd, SupportedLaneCount};
+use std::simd::Simd;
 
 use super::SamplesIter;
 
@@ -226,10 +226,7 @@ impl<'slice, 'sample> Block<'slice, 'sample> {
     pub fn to_channel_simd<const LANES: usize>(
         &self,
         sample_index: usize,
-    ) -> Option<Simd<f32, LANES>>
-    where
-        LaneCount<LANES>: SupportedLaneCount,
-    {
+    ) -> Option<Simd<f32, LANES>> {
         if sample_index > self.samples() {
             return None;
         }
@@ -258,10 +255,7 @@ impl<'slice, 'sample> Block<'slice, 'sample> {
     pub unsafe fn to_channel_simd_unchecked<const LANES: usize>(
         &self,
         sample_index: usize,
-    ) -> Simd<f32, LANES>
-    where
-        LaneCount<LANES>: SupportedLaneCount,
-    {
+    ) -> Simd<f32, LANES> {
         let mut values = [0.0; LANES];
         for (channel_idx, value) in values.iter_mut().enumerate() {
             *value = *(&(*self.buffers))
@@ -284,10 +278,7 @@ impl<'slice, 'sample> Block<'slice, 'sample> {
         &mut self,
         sample_index: usize,
         vector: Simd<f32, LANES>,
-    ) -> bool
-    where
-        LaneCount<LANES>: SupportedLaneCount,
-    {
+    ) -> bool {
         if sample_index > self.samples() {
             return false;
         }
@@ -319,9 +310,7 @@ impl<'slice, 'sample> Block<'slice, 'sample> {
         &mut self,
         sample_index: usize,
         vector: Simd<f32, LANES>,
-    ) where
-        LaneCount<LANES>: SupportedLaneCount,
-    {
+    ) {
         let values = vector.to_array();
         for (channel_idx, value) in values.into_iter().enumerate() {
             *(&mut (*self.buffers))

--- a/src/buffer/samples.rs
+++ b/src/buffer/samples.rs
@@ -3,7 +3,7 @@
 use std::marker::PhantomData;
 
 #[cfg(feature = "simd")]
-use std::simd::{LaneCount, Simd, SupportedLaneCount};
+use std::simd::Simd;
 
 /// An iterator over all samples in a buffer or block, yielding iterators over each channel for
 /// every sample. This iteration order offers good cache locality for per-sample access.
@@ -168,10 +168,7 @@ impl<'slice, 'sample> ChannelSamples<'slice, 'sample> {
     /// all values.
     #[cfg(feature = "simd")]
     #[inline]
-    pub fn to_simd<const LANES: usize>(&self) -> Simd<f32, LANES>
-    where
-        LaneCount<LANES>: SupportedLaneCount,
-    {
+    pub fn to_simd<const LANES: usize>(&self) -> Simd<f32, LANES> {
         let used_lanes = self.len().max(LANES);
         let mut values = [0.0; LANES];
         for (channel_idx, value) in values.iter_mut().enumerate().take(used_lanes) {
@@ -193,10 +190,7 @@ impl<'slice, 'sample> ChannelSamples<'slice, 'sample> {
     /// Undefined behavior if `LANES > channels.len()`.
     #[cfg(feature = "simd")]
     #[inline]
-    pub unsafe fn to_simd_unchecked<const LANES: usize>(&self) -> Simd<f32, LANES>
-    where
-        LaneCount<LANES>: SupportedLaneCount,
-    {
+    pub unsafe fn to_simd_unchecked<const LANES: usize>(&self) -> Simd<f32, LANES> {
         let mut values = [0.0; LANES];
         for (channel_idx, value) in values.iter_mut().enumerate() {
             *value = *(&(*self.buffers))
@@ -212,10 +206,7 @@ impl<'slice, 'sample> ChannelSamples<'slice, 'sample> {
     #[cfg(feature = "simd")]
     #[allow(clippy::wrong_self_convention)]
     #[inline]
-    pub fn from_simd<const LANES: usize>(&mut self, vector: Simd<f32, LANES>)
-    where
-        LaneCount<LANES>: SupportedLaneCount,
-    {
+    pub fn from_simd<const LANES: usize>(&mut self, vector: Simd<f32, LANES>) {
         let used_lanes = self.len().max(LANES);
         let values = vector.to_array();
         for (channel_idx, value) in values.into_iter().enumerate().take(used_lanes) {
@@ -236,10 +227,7 @@ impl<'slice, 'sample> ChannelSamples<'slice, 'sample> {
     #[cfg(feature = "simd")]
     #[allow(clippy::wrong_self_convention)]
     #[inline]
-    pub unsafe fn from_simd_unchecked<const LANES: usize>(&mut self, vector: Simd<f32, LANES>)
-    where
-        LaneCount<LANES>: SupportedLaneCount,
-    {
+    pub unsafe fn from_simd_unchecked<const LANES: usize>(&mut self, vector: Simd<f32, LANES>) {
         let values = vector.to_array();
         for (channel_idx, value) in values.into_iter().enumerate() {
             *(&mut (*self.buffers))

--- a/src/wrapper/vst3.rs
+++ b/src/wrapper/vst3.rs
@@ -28,7 +28,7 @@ macro_rules! nih_export_vst3 {
             use ::std::collections::HashSet;
             use ::std::ffi::c_void;
 
-            // `vst3_sys` is imported from the VST3 wrapper module
+            // `vst3` is imported from the VST3 wrapper module
             use $crate::wrapper::vst3::{PluginInfo, Wrapper};
             use $crate::wrapper::vst3::vst3::Steinberg::{kInvalidArgument, kResultOk, tresult, int32, FIDString, TUID};
             use $crate::wrapper::vst3::vst3::Steinberg::{

--- a/src/wrapper/vst3/factory.rs
+++ b/src/wrapper/vst3/factory.rs
@@ -5,8 +5,10 @@
 //! frustrating and error prone, most code that does not specifically depend on all of the exposed
 //! plugin types was moved back to this module so it can be compiled and type checked as normal.
 
-use vst3_sys::base::{
-    ClassCardinality, FactoryFlags, PClassInfo, PClassInfo2, PClassInfoW, PFactoryInfo,
+use vst3::Steinberg::Vst::ComponentFlags_;
+use vst3::Steinberg::{
+    PClassInfo, PClassInfo2, PClassInfoW, PClassInfo_::ClassCardinality_, PFactoryInfo,
+    PFactoryInfo_::FactoryFlags_,
 };
 
 use super::subcategories::Vst3SubCategory;
@@ -53,7 +55,7 @@ impl PluginInfo {
         strlcpy(&mut info.vendor, self.vendor);
         strlcpy(&mut info.url, self.url);
         strlcpy(&mut info.email, self.email);
-        info.flags = FactoryFlags::kUnicode as i32;
+        info.flags = FactoryFlags_::kUnicode as i32;
 
         info
     }
@@ -62,8 +64,8 @@ impl PluginInfo {
     /// `IPluginFactory`.
     pub fn create_class_info(&self) -> PClassInfo {
         let mut info: PClassInfo = unsafe { std::mem::zeroed() };
-        info.cid.data = *self.cid;
-        info.cardinality = ClassCardinality::kManyInstances as i32;
+        info.cid = self.cid.map(|b| b as i8);
+        info.cardinality = ClassCardinality_::kManyInstances as i32;
         strlcpy(&mut info.category, "Audio Module Class");
         strlcpy(&mut info.name, self.name);
 
@@ -74,15 +76,15 @@ impl PluginInfo {
     /// `IPluginFactory2`.
     pub fn create_class_info_2(&self) -> PClassInfo2 {
         let mut info: PClassInfo2 = unsafe { std::mem::zeroed() };
-        info.cid.data = *self.cid;
-        info.cardinality = ClassCardinality::kManyInstances as i32;
+        info.cid = self.cid.map(|b| b as i8);
+        info.cardinality = ClassCardinality_::kManyInstances as i32;
         strlcpy(&mut info.category, "Audio Module Class");
         strlcpy(&mut info.name, self.name);
-        info.class_flags = 1 << 1; // kSimpleModeSupported
-        strlcpy(&mut info.subcategories, &self.subcategories);
+        info.classFlags = ComponentFlags_::kSimpleModeSupported;
+        strlcpy(&mut info.subCategories, &self.subcategories);
         strlcpy(&mut info.vendor, self.vendor);
         strlcpy(&mut info.version, self.version);
-        strlcpy(&mut info.sdk_version, VST3_SDK_VERSION);
+        strlcpy(&mut info.sdkVersion, VST3_SDK_VERSION);
 
         info
     }
@@ -91,15 +93,15 @@ impl PluginInfo {
     /// `IPluginFactory3`.
     pub fn create_class_info_unicode(&self) -> PClassInfoW {
         let mut info: PClassInfoW = unsafe { std::mem::zeroed() };
-        info.cid.data = *self.cid;
-        info.cardinality = ClassCardinality::kManyInstances as i32;
+        info.cid = self.cid.map(|b| b as i8);
+        info.cardinality = ClassCardinality_::kManyInstances as i32;
         strlcpy(&mut info.category, "Audio Module Class");
         u16strlcpy(&mut info.name, self.name);
-        info.class_flags = 1 << 1; // kSimpleModeSupported
-        strlcpy(&mut info.subcategories, &self.subcategories);
+        info.classFlags = ComponentFlags_::kSimpleModeSupported;
+        strlcpy(&mut info.subCategories, &self.subcategories);
         u16strlcpy(&mut info.vendor, self.vendor);
         u16strlcpy(&mut info.version, self.version);
-        u16strlcpy(&mut info.sdk_version, VST3_SDK_VERSION);
+        u16strlcpy(&mut info.sdkVersion, VST3_SDK_VERSION);
 
         info
     }

--- a/src/wrapper/vst3/factory.rs
+++ b/src/wrapper/vst3/factory.rs
@@ -80,7 +80,7 @@ impl PluginInfo {
         info.cardinality = ClassCardinality_::kManyInstances as i32;
         strlcpy(&mut info.category, "Audio Module Class");
         strlcpy(&mut info.name, self.name);
-        info.classFlags = ComponentFlags_::kSimpleModeSupported;
+        info.classFlags = ComponentFlags_::kSimpleModeSupported as u32;
         strlcpy(&mut info.subCategories, &self.subcategories);
         strlcpy(&mut info.vendor, self.vendor);
         strlcpy(&mut info.version, self.version);
@@ -97,7 +97,7 @@ impl PluginInfo {
         info.cardinality = ClassCardinality_::kManyInstances as i32;
         strlcpy(&mut info.category, "Audio Module Class");
         u16strlcpy(&mut info.name, self.name);
-        info.classFlags = ComponentFlags_::kSimpleModeSupported;
+        info.classFlags = ComponentFlags_::kSimpleModeSupported as u32;
         strlcpy(&mut info.subCategories, &self.subcategories);
         u16strlcpy(&mut info.vendor, self.vendor);
         u16strlcpy(&mut info.version, self.version);

--- a/src/wrapper/vst3/inner.rs
+++ b/src/wrapper/vst3/inner.rs
@@ -647,7 +647,7 @@ impl<P: Vst3Plugin> MainThreadExecutor<Task<P>> for WrapperInner<P> {
             Task::RequestResize => match &*self.plug_view.read() {
                 Some(plug_view) => unsafe {
                     nih_debug_assert!(is_gui_thread);
-                    let success = plug_view.request_resize();
+                    let success = WrapperView::request_resize(plug_view);
                     nih_debug_assert!(success, "Failed requesting a window resize");
                 },
                 None => nih_debug_assert_failure!("Can't resize a closed editor"),

--- a/src/wrapper/vst3/inner.rs
+++ b/src/wrapper/vst3/inner.rs
@@ -46,9 +46,11 @@ pub(crate) struct WrapperInner<P: Vst3Plugin> {
     /// [`IEditController::set_component_handler`].
     pub component_handler: AtomicRefCell<Option<ComPtr<IComponentHandler>>>,
 
-    /// Our own [`IPlugView`] instance. This is set while the editor is actually visible (which is
-    /// different form the lifetime of [`WrapperView`][super::WrapperView] itself).
+    /// Our own [`IPlugView`] instance.
     pub plug_view: RwLock<Option<ComWrapper<WrapperView<P>>>>,
+
+    /// Whether the editor is currently open. This is changed by the attached and removed functions on IPlugViewTrait
+    pub is_editor_open: AtomicBool,
 
     /// A realtime-safe task queue so the plugin can schedule tasks that need to be run later on the
     /// GUI thread. This field should not be used directly for posting tasks. This should be done
@@ -289,6 +291,8 @@ impl<P: Vst3Plugin> WrapperInner<P> {
 
             plug_view: RwLock::new(None),
 
+            is_editor_open: AtomicBool::new(false),
+
             event_loop: AtomicRefCell::new(None),
 
             is_processing: AtomicBool::new(false),
@@ -414,12 +418,19 @@ impl<P: Vst3Plugin> WrapperInner<P> {
             // regular event loop. If the editor gets dropped while there's still outstanding work
             // left in the run loop task queue, then those tasks will be posted to the regular event
             // loop so no work is lost.
-            match &*self.plug_view.read() {
-                Some(plug_view) => match plug_view.do_maybe_in_run_loop(task) {
+            if self.is_editor_open.load(Ordering::Relaxed) {
+                match self
+                    .plug_view
+                    .read()
+                    .clone()
+                    .unwrap()
+                    .do_maybe_in_run_loop(task)
+                {
                     Ok(()) => true,
                     Err(task) => event_loop.schedule_gui(task),
-                },
-                None => event_loop.schedule_gui(task),
+                }
+            } else {
+                event_loop.schedule_gui(task)
             }
         }
     }
@@ -600,7 +611,7 @@ impl<P: Vst3Plugin> WrapperInner<P> {
         // TODO: Right now there's no way to know if loading the state changed the GUI's size. We
         //       could keep track of the last known size and compare the GUI's current size against
         //       that but that also seems brittle.
-        if self.plug_view.read().is_some() {
+        if self.is_editor_open.load(Ordering::SeqCst) {
             let task_posted = self.schedule_gui(Task::RequestResize);
             nih_debug_assert!(task_posted, "The task queue is full, dropping task...");
         }
@@ -615,14 +626,14 @@ impl<P: Vst3Plugin> MainThreadExecutor<Task<P>> for WrapperInner<P> {
         match task {
             Task::PluginTask(task) => (self.task_executor.lock())(task),
             Task::ParameterValuesChanged => {
-                if self.plug_view.read().is_some() {
+                if self.is_editor_open.load(Ordering::SeqCst) {
                     if let Some(editor) = self.editor.borrow().as_ref() {
                         editor.lock().param_values_changed();
                     }
                 }
             }
             Task::ParameterValueChanged(param_hash, normalized_value) => {
-                if self.plug_view.read().is_some() {
+                if self.is_editor_open.load(Ordering::SeqCst) {
                     if let Some(editor) = self.editor.borrow().as_ref() {
                         let param_id = &self.param_id_by_hash[&param_hash];
                         editor
@@ -644,14 +655,18 @@ impl<P: Vst3Plugin> MainThreadExecutor<Task<P>> for WrapperInner<P> {
                 },
                 None => nih_debug_assert_failure!("Component handler not yet set"),
             },
-            Task::RequestResize => match &*self.plug_view.read() {
-                Some(plug_view) => unsafe {
-                    nih_debug_assert!(is_gui_thread);
-                    let success = WrapperView::request_resize(plug_view);
-                    nih_debug_assert!(success, "Failed requesting a window resize");
-                },
-                None => nih_debug_assert_failure!("Can't resize a closed editor"),
-            },
+            Task::RequestResize => {
+                if self.is_editor_open.load(Ordering::SeqCst) {
+                    unsafe {
+                        nih_debug_assert!(is_gui_thread);
+                        let success =
+                            WrapperView::request_resize(&self.plug_view.read().clone().unwrap());
+                        nih_debug_assert!(success, "Failed requesting a window resize");
+                    }
+                } else {
+                    nih_debug_assert_failure!("Can't resize a closed editor");
+                }
+            }
         }
     }
 }

--- a/src/wrapper/vst3/note_expressions.rs
+++ b/src/wrapper/vst3/note_expressions.rs
@@ -1,7 +1,7 @@
 //! Special handling for note expressions, because VST3 makes this a lot more complicated than it
 //! needs to be. We only support the predefined expressions.
 
-use vst3_sys::vst::{NoteExpressionValueEvent, NoteOnEvent};
+use vst3::Steinberg::Vst::{NoteExpressionValueEvent, NoteOnEvent};
 
 use crate::prelude::{NoteEvent, SysExMessage};
 
@@ -93,7 +93,7 @@ impl NoteExpressionController {
     /// Register the note ID from a note on event so it can later be retrieved when handling a note
     /// expression value event.
     pub fn register_note(&mut self, event: &NoteOnEvent) {
-        self.note_ids[self.note_ids_idx] = (event.note_id, event.pitch as u8, event.channel as u8);
+        self.note_ids[self.note_ids_idx] = (event.noteId, event.pitch as u8, event.channel as u8);
         self.note_ids_idx = (self.note_ids_idx + 1) % NOTE_IDS_LEN;
     }
 
@@ -109,9 +109,9 @@ impl NoteExpressionController {
         let (note_id, note, channel) = *self
             .note_ids
             .iter()
-            .find(|(note_id, _, _)| *note_id == event.note_id)?;
+            .find(|(note_id, _, _)| *note_id == event.noteId)?;
 
-        match event.type_id {
+        match event.typeId {
             VOLUME_EXPRESSION_ID => Some(NoteEvent::PolyVolume {
                 timing,
                 voice_id: Some(note_id),
@@ -172,33 +172,33 @@ impl NoteExpressionController {
     ) -> Option<NoteExpressionValueEvent> {
         match &event {
             NoteEvent::PolyVolume { gain, .. } => Some(NoteExpressionValueEvent {
-                type_id: VOLUME_EXPRESSION_ID,
-                note_id,
+                typeId: VOLUME_EXPRESSION_ID,
+                noteId: note_id,
                 value: *gain as f64 / 4.0,
             }),
             NoteEvent::PolyPan { pan, .. } => Some(NoteExpressionValueEvent {
-                type_id: PAN_EXPRESSION_ID,
-                note_id,
+                typeId: PAN_EXPRESSION_ID,
+                noteId: note_id,
                 value: (*pan as f64 + 1.0) / 2.0,
             }),
             NoteEvent::PolyTuning { tuning, .. } => Some(NoteExpressionValueEvent {
-                type_id: TUNING_EXPRESSION_ID,
-                note_id,
+                typeId: TUNING_EXPRESSION_ID,
+                noteId: note_id,
                 value: (*tuning as f64 / 240.0) + 0.5,
             }),
             NoteEvent::PolyVibrato { vibrato, .. } => Some(NoteExpressionValueEvent {
-                type_id: VIBRATO_EXPRESSION_ID,
-                note_id,
+                typeId: VIBRATO_EXPRESSION_ID,
+                noteId: note_id,
                 value: *vibrato as f64,
             }),
             NoteEvent::PolyExpression { expression, .. } => Some(NoteExpressionValueEvent {
-                type_id: EXPRESSION_EXPRESSION_ID,
-                note_id,
+                typeId: EXPRESSION_EXPRESSION_ID,
+                noteId: note_id,
                 value: *expression as f64,
             }),
             NoteEvent::PolyBrightness { brightness, .. } => Some(NoteExpressionValueEvent {
-                type_id: BRIGHTNESS_EXPRESSION_ID,
-                note_id,
+                typeId: BRIGHTNESS_EXPRESSION_ID,
+                noteId: note_id,
                 value: *brightness as f64,
             }),
             _ => None,

--- a/src/wrapper/vst3/param_units.rs
+++ b/src/wrapper/vst3/param_units.rs
@@ -7,7 +7,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use vst3_sys::vst::kRootUnitId;
+use vst3::Steinberg::Vst::kRootUnitId;
 
 /// Transforms a map containing parameter hashes and slash-separated paths to an array of VST3 units
 /// and a mapping for each parameter hash to a unit (or to `None` if they belong to the root unit).

--- a/src/wrapper/vst3/util.rs
+++ b/src/wrapper/vst3/util.rs
@@ -4,7 +4,7 @@ use widestring::U16CString;
 
 /// When `Plugin::MIDI_INPUT` is set to `MidiConfig::MidiCCs` or higher then we'll register 130*16
 /// additional parameters to handle MIDI CCs, channel pressure, and pitch bend, in that order.
-/// vst3-sys doesn't expose these constants.
+/// vst3 doesn't expose these constants.
 pub const VST3_MIDI_CCS: u32 = 130;
 pub const VST3_MIDI_CHANNELS: u32 = 16;
 /// The number of parameters we'll need to register if the plugin accepts MIDI CCs.

--- a/src/wrapper/vst3/view.rs
+++ b/src/wrapper/vst3/view.rs
@@ -21,7 +21,7 @@ use crate::plugin::vst3::Vst3Plugin;
 use crate::prelude::{Editor, ParentWindowHandle};
 
 // Thanks for putting this behind a platform-specific ifdef...
-// NOTE: This should also be used on the BSDs, but vst3-sys exposes these interfaces only for Linux
+// NOTE: This should also be used on the BSDs, which should be possible since vst3-sys is replaced by the vst3 crate
 #[cfg(target_os = "linux")]
 use {
     crate::event_loop::{EventLoop, MainThreadExecutor, TASK_QUEUE_CAPACITY},
@@ -32,7 +32,7 @@ use {
     },
 };
 
-// Window handle type constants missing from vst3-sys
+// Window handle type constants missing from vst3
 #[allow(unused)]
 const VST3_PLATFORM_HWND: &str = "HWND";
 #[allow(unused)]
@@ -44,8 +44,9 @@ const VST3_PLATFORM_UIVIEW: &str = "UIView";
 #[allow(unused)]
 const VST3_PLATFORM_X11_WINDOW: &str = "X11EmbedWindowID";
 
-/// FIXME: vst3-sys does not allow you to conditionally define fields with #[cfg()], so this is a
-///        workaround to define the field outside of the struct
+/// FIXME: vst3-sys did not allow you to conditionally define fields with #[cfg()], so this is a
+/// workaround to define the field outside of the struct. Since vst3-sys is replaced by the vst3
+/// crate this should be fixable.
 #[cfg(target_os = "linux")]
 struct RunLoopEventHandlerWrapper<P: Vst3Plugin>(RwLock<Option<Box<RunLoopEventHandler<P>>>>);
 #[cfg(not(target_os = "linux"))]
@@ -62,7 +63,7 @@ pub(crate) struct WrapperView<P: Vst3Plugin> {
     plug_frame: RwLock<Option<ComPtr<IPlugFrame>>>,
     /// Allows handling events events on the host's GUI thread when using Linux. Needed because
     /// otherwise REAPER doesn't like us very much. The event handler could be implemented directly
-    /// on this object but vst3-sys does not let us conditionally implement interfaces.
+    /// on this object since vst3-sys is replaced by the vst3 crate.
     run_loop_event_handler: RunLoopEventHandlerWrapper<P>,
 
     /// The DPI scaling factor as passed to the [IPlugViewContentScaleSupport::set_scale_factor()]
@@ -77,9 +78,10 @@ impl<P: Vst3Plugin> Class for WrapperView<P> {
 }
 
 /// Allow handling tasks on the host's GUI thread on Linux. This doesn't need to be a separate
-/// struct, but vst3-sys does not let us implement interfaces conditionally and the interface is
-/// only exposed when compiling on Linux. The struct will register itself when calling
-/// [`RunLoopEventHandler::new()`] and it will unregister itself when it gets dropped.
+/// struct, but vst3-sys did not let us implement interfaces conditionally and the interface is
+/// only exposed when compiling on Linux. This should be fixable since we use the vst3 crate.
+/// The struct will register itself when calling [`RunLoopEventHandler::new()`] and it will
+/// unregister itself when it gets dropped.
 #[cfg(target_os = "linux")]
 struct RunLoopEventHandler<P: Vst3Plugin> {
     /// We need access to the inner wrapper so we that we can post any outstanding tasks there when

--- a/src/wrapper/vst3/view.rs
+++ b/src/wrapper/vst3/view.rs
@@ -27,6 +27,7 @@ use {
     crate::event_loop::{EventLoop, MainThreadExecutor, TASK_QUEUE_CAPACITY},
     crossbeam::queue::ArrayQueue,
     libc,
+    std::cell::Cell,
     vst3::Steinberg::Linux::{
         FileDescriptor, IEventHandler, IEventHandlerTrait, IRunLoop, IRunLoopTrait,
     },
@@ -108,7 +109,7 @@ struct RunLoopEventHandler<P: Vst3Plugin> {
     tasks: ArrayQueue<Task<P>>,
 
     /// We need access to the IEventHandler pointer to be able to call `IRunLoop::unregisterEventHandler()` when this object gets dropped.
-    com_ptr: RwLock<Option<ComPtr<IEventHandler>>>,
+    event_handler_ptr: Cell<*mut IEventHandler>,
 }
 
 #[cfg(target_os = "linux")]
@@ -217,16 +218,16 @@ impl<P: Vst3Plugin> RunLoopEventHandler<P> {
             socket_read_fd,
             socket_write_fd,
             tasks: ArrayQueue::new(TASK_QUEUE_CAPACITY),
-            com_ptr: RwLock::new(None),
+            event_handler_ptr: Cell::new(std::ptr::null_mut()),
         });
-        let com_ptr = handler.to_com_ptr::<IEventHandler>();
-        *handler.com_ptr.write() = com_ptr.clone();
+        let event_handler_ptr = handler.to_com_ptr::<IEventHandler>().unwrap().into_raw();
+        handler.event_handler_ptr.set(event_handler_ptr);
 
         assert_eq!(
             unsafe {
                 handler
                     .run_loop
-                    .registerEventHandler(com_ptr.unwrap().into_raw(), handler.socket_read_fd)
+                    .registerEventHandler(event_handler_ptr, handler.socket_read_fd)
             },
             kResultOk
         );
@@ -533,7 +534,7 @@ impl<P: Vst3Plugin> Drop for RunLoopEventHandler<P> {
 
         unsafe {
             self.run_loop
-                .unregisterEventHandler(self.com_ptr.read().clone().unwrap().into_raw());
+                .unregisterEventHandler(self.event_handler_ptr.get());
         }
     }
 }

--- a/src/wrapper/vst3/view.rs
+++ b/src/wrapper/vst3/view.rs
@@ -48,7 +48,9 @@ const VST3_PLATFORM_X11_WINDOW: &str = "X11EmbedWindowID";
 /// workaround to define the field outside of the struct. Since vst3-sys is replaced by the vst3
 /// crate this should be fixable.
 #[cfg(target_os = "linux")]
-struct RunLoopEventHandlerWrapper<P: Vst3Plugin>(RwLock<Option<Box<RunLoopEventHandler<P>>>>);
+struct RunLoopEventHandlerWrapper<P: Vst3Plugin>(
+    RwLock<Option<ComWrapper<RunLoopEventHandler<P>>>>,
+);
 #[cfg(not(target_os = "linux"))]
 struct RunLoopEventHandlerWrapper<P: Vst3Plugin>(std::marker::PhantomData<P>);
 
@@ -104,6 +106,14 @@ struct RunLoopEventHandler<P: Vst3Plugin> {
     /// [`on_main_thread()`][Self::on_main_thread()] on the main thread, and then continue to pop
     /// tasks off this queue there until it is empty.
     tasks: ArrayQueue<Task<P>>,
+
+    /// We need access to the IEventHandler pointer to be able to call `IRunLoop::unregisterEventHandler()` when this object gets dropped.
+    com_ptr: RwLock<Option<ComPtr<IEventHandler>>>,
+}
+
+#[cfg(target_os = "linux")]
+impl<P: Vst3Plugin> Class for RunLoopEventHandler<P> {
+    type Interfaces = (IEventHandler,);
 }
 
 impl<P: Vst3Plugin> WrapperView<P> {
@@ -186,7 +196,7 @@ impl<P: Vst3Plugin> WrapperView<P> {
 
 #[cfg(target_os = "linux")]
 impl<P: Vst3Plugin> RunLoopEventHandler<P> {
-    pub fn new(inner: Arc<WrapperInner<P>>, run_loop: ComPtr<IRunLoop>) -> Box<Self> {
+    pub fn new(inner: Arc<WrapperInner<P>>, run_loop: ComPtr<IRunLoop>) -> ComWrapper<Self> {
         let mut sockets = [0i32; 2];
         assert_eq!(
             unsafe {
@@ -201,21 +211,22 @@ impl<P: Vst3Plugin> RunLoopEventHandler<P> {
         );
         let [socket_read_fd, socket_write_fd] = sockets;
 
-        let handler = Box::new(RunLoopEventHandler {
+        let mut handler = ComWrapper::new(RunLoopEventHandler {
             inner,
             run_loop,
             socket_read_fd,
             socket_write_fd,
             tasks: ArrayQueue::new(TASK_QUEUE_CAPACITY),
+            com_ptr: RwLock::new(None),
         });
-
-        let handler_ptr = &*handler as *const _ as *mut _;
+        let com_ptr = handler.to_com_ptr::<IEventHandler>();
+        *handler.com_ptr.write() = com_ptr.clone();
 
         assert_eq!(
             unsafe {
                 handler
                     .run_loop
-                    .registerEventHandler(handler_ptr, handler.socket_read_fd)
+                    .registerEventHandler(com_ptr.unwrap().into_raw(), handler.socket_read_fd)
             },
             kResultOk
         );
@@ -522,7 +533,7 @@ impl<P: Vst3Plugin> Drop for RunLoopEventHandler<P> {
 
         unsafe {
             self.run_loop
-                .unregisterEventHandler(self as *const _ as *mut _);
+                .unregisterEventHandler(self.com_ptr.read().clone().unwrap().into_raw());
         }
     }
 }

--- a/src/wrapper/vst3/view.rs
+++ b/src/wrapper/vst3/view.rs
@@ -47,7 +47,7 @@ const VST3_PLATFORM_X11_WINDOW: &str = "X11EmbedWindowID";
 
 /// FIXME: vst3-sys did not allow you to conditionally define fields with #[cfg()], so this is a
 /// workaround to define the field outside of the struct. Since vst3-sys is replaced by the vst3
-/// crate this should be fixable.
+/// crate this might be fixable.
 #[cfg(target_os = "linux")]
 struct RunLoopEventHandlerWrapper<P: Vst3Plugin>(
     RwLock<Option<ComWrapper<RunLoopEventHandler<P>>>>,
@@ -65,7 +65,7 @@ pub(crate) struct WrapperView<P: Vst3Plugin> {
     /// The `IPlugFrame` instance passed by the host during [IPlugView::set_frame()].
     plug_frame: RwLock<Option<ComPtr<IPlugFrame>>>,
     /// Allows handling events events on the host's GUI thread when using Linux. Needed because
-    /// otherwise REAPER doesn't like us very much. The event handler could be implemented directly
+    /// otherwise REAPER doesn't like us very much. The event handler could possibly be implemented directly
     /// on this object since vst3-sys is replaced by the vst3 crate.
     run_loop_event_handler: RunLoopEventHandlerWrapper<P>,
 
@@ -320,7 +320,7 @@ impl<P: Vst3Plugin> IPlugViewTrait for WrapperView<P> {
                     .lock()
                     .spawn(parent_handle, self.inner.clone().make_gui_context()),
             );
-            // *self.inner.plug_view.write() = Some(ObjectPtr::from(self));
+            self.inner.is_editor_open.store(true, Ordering::SeqCst);
 
             kResultOk
         } else {
@@ -335,7 +335,7 @@ impl<P: Vst3Plugin> IPlugViewTrait for WrapperView<P> {
     unsafe fn removed(&self) -> tresult {
         let mut editor_handle = self.editor_handle.write();
         if editor_handle.is_some() {
-            *self.inner.plug_view.write() = None;
+            self.inner.is_editor_open.store(false, Ordering::SeqCst);
             *editor_handle = None;
 
             kResultOk
@@ -414,7 +414,7 @@ impl<P: Vst3Plugin> IPlugViewTrait for WrapperView<P> {
                         .cast()
                         .map(|run_loop| RunLoopEventHandler::new(self.inner.clone(), run_loop));
                 }
-                // *self.plug_frame.write() = Some(ComPtr::from(frame));
+                *self.plug_frame.write() = Some(frame.to_com_ptr());
             }
             None => {
                 #[cfg(target_os = "linux")]

--- a/src/wrapper/vst3/view.rs
+++ b/src/wrapper/vst3/view.rs
@@ -209,7 +209,7 @@ impl<P: Vst3Plugin> RunLoopEventHandler<P> {
             tasks: ArrayQueue::new(TASK_QUEUE_CAPACITY),
         });
 
-        let handler_ptr: *mut IEventHandler = &handler as *const _ as *mut _;
+        let handler_ptr = &*handler as *const _ as *mut _;
 
         assert_eq!(
             unsafe {
@@ -522,7 +522,7 @@ impl<P: Vst3Plugin> Drop for RunLoopEventHandler<P> {
 
         unsafe {
             self.run_loop
-                .unregisterEventHandler(&self as *const _ as *mut _);
+                .unregisterEventHandler(self as *const _ as *mut _);
         }
     }
 }

--- a/src/wrapper/vst3/wrapper.rs
+++ b/src/wrapper/vst3/wrapper.rs
@@ -11,22 +11,20 @@ use vst3::Steinberg::Vst::ProcessContext_::StatesAndFlags_::{
 };
 use vst3::Steinberg::Vst::{
     kNoParamId, kNoParentUnitId, kNoProgramListId, kRootUnitId, BusDirection, CString, CtrlNumber,
-    DataEvent, Event, Event_::EventTypes, Event_::EventTypes_, IAudioProcessor,
-    IAudioProcessorTrait, IComponent, IComponentHandler, IComponentTrait, IEditController,
-    IEditControllerTrait, IEventList, IEventListTrait, IMidiMapping, IMidiMappingTrait,
-    INoteExpressionController, INoteExpressionControllerTrait, IParamValueQueue,
-    IParamValueQueueTrait, IParameterChanges, IParameterChangesTrait, IProcessContextRequirements,
+    DataEvent, Event, Event_::EventTypes_, IAudioProcessor, IAudioProcessorTrait, IComponent,
+    IComponentHandler, IComponentTrait, IEditController, IEditControllerTrait, IEventListTrait,
+    IMidiMapping, IMidiMappingTrait, INoteExpressionController, INoteExpressionControllerTrait,
+    IParamValueQueueTrait, IParameterChangesTrait, IProcessContextRequirements,
     IProcessContextRequirementsTrait, IProcessContextRequirements_, IUnitInfo, IUnitInfoTrait,
     IoMode, LegacyMIDICCOutEvent, MediaType, NoteExpressionTypeID, NoteExpressionTypeInfo,
     NoteExpressionValue, NoteExpressionValueDescription, NoteOffEvent, NoteOnEvent, ParamID,
-    ParamValue, ParameterInfo, ParameterInfo_::ParameterFlags, ParameterInfo_::ParameterFlags_,
-    PolyPressureEvent, ProcessData, ProcessModes, ProcessModes_, ProcessSetup, ProgramListID,
-    ProgramListInfo, SpeakerArrangement, String128, TChar, UnitID, UnitInfo,
+    ParamValue, ParameterInfo, ParameterInfo_::ParameterFlags_, PolyPressureEvent, ProcessData,
+    ProcessModes_, ProcessSetup, ProgramListID, ProgramListInfo, SpeakerArrangement, String128,
+    TChar, UnitID, UnitInfo,
 };
 use vst3::Steinberg::{
     int16, int32, kInvalidArgument, kNoInterface, kResultFalse, kResultOk, tresult, uint32,
-    FIDString, FUnknown, IBStream, IBStreamTrait, IPlugView, IPluginBase, IPluginBaseTrait, TBool,
-    TUID,
+    FIDString, FUnknown, IBStream, IBStreamTrait, IPlugView, IPluginBaseTrait, TBool, TUID,
 };
 use vst3::{Class, ComRef, ComWrapper};
 use widestring::U16CStr;
@@ -1353,12 +1351,12 @@ impl<P: Vst3Plugin> IAudioProcessorTrait for Wrapper<P> {
                     if !data.processContext.is_null() {
                         let context = &*data.processContext;
 
-                        transport.playing = context.state & kPlaying != 0;
-                        transport.recording = context.state & kRecording != 0;
-                        if context.state & kTempoValid != 0 {
+                        transport.playing = context.state & kPlaying as u32 != 0;
+                        transport.recording = context.state & kRecording as u32 != 0;
+                        if context.state & kTempoValid as u32 != 0 {
                             transport.tempo = Some(context.tempo);
                         }
-                        if context.state & kTimeSigValid != 0 {
+                        if context.state & kTimeSigValid as u32 != 0 {
                             transport.time_sig_numerator = Some(context.timeSigNumerator);
                             transport.time_sig_denominator = Some(context.timeSigDenominator);
                         }
@@ -1366,10 +1364,10 @@ impl<P: Vst3Plugin> IAudioProcessorTrait for Wrapper<P> {
                         // We need to compensate for the block splitting here
                         transport.pos_samples =
                             Some(context.projectTimeSamples + block_start as i64);
-                        if context.state & kProjectTimeMusicValid != 0 {
+                        if context.state & kProjectTimeMusicValid as u32 != 0 {
                             if P::SAMPLE_ACCURATE_AUTOMATION
                                 && block_start > 0
-                                && (context.state & kTempoValid != 0)
+                                && (context.state & kTempoValid as u32 != 0)
                             {
                                 transport.pos_beats = Some(
                                     context.projectTimeMusic
@@ -1381,7 +1379,7 @@ impl<P: Vst3Plugin> IAudioProcessorTrait for Wrapper<P> {
                             }
                         }
 
-                        if context.state & kBarPositionValid != 0 {
+                        if context.state & kBarPositionValid as u32 != 0 {
                             if P::SAMPLE_ACCURATE_AUTOMATION && block_start > 0 {
                                 // The transport object knows how to recompute this from the other information
                                 transport.bar_start_pos_beats =
@@ -1393,7 +1391,9 @@ impl<P: Vst3Plugin> IAudioProcessorTrait for Wrapper<P> {
                                 transport.bar_start_pos_beats = Some(context.barPositionMusic);
                             }
                         }
-                        if context.state & kCycleActive != 0 && context.state & kCycleValid != 0 {
+                        if context.state & kCycleActive as u32 != 0
+                            && context.state & kCycleValid as u32 != 0
+                        {
                             transport.loop_range_beats =
                                 Some((context.cycleStartMusic, context.cycleEndMusic));
                         }
@@ -1793,12 +1793,12 @@ impl<P: Vst3Plugin> INoteExpressionControllerTrait for Wrapper<P> {
 
 impl<P: Vst3Plugin> IProcessContextRequirementsTrait for Wrapper<P> {
     unsafe fn getProcessContextRequirements(&self) -> uint32 {
-        IProcessContextRequirements_::Flags_::kNeedProjectTimeMusic
+        (IProcessContextRequirements_::Flags_::kNeedProjectTimeMusic
             | IProcessContextRequirements_::Flags_::kNeedBarPositionMusic
             | IProcessContextRequirements_::Flags_::kNeedCycleMusic
             | IProcessContextRequirements_::Flags_::kNeedTimeSignature
             | IProcessContextRequirements_::Flags_::kNeedTempo
-            | IProcessContextRequirements_::Flags_::kNeedTransportState
+            | IProcessContextRequirements_::Flags_::kNeedTransportState) as u32
     }
 }
 

--- a/src/wrapper/vst3/wrapper.rs
+++ b/src/wrapper/vst3/wrapper.rs
@@ -702,7 +702,9 @@ impl<P: Vst3Plugin> IEditControllerTrait for Wrapper<P> {
         match self.inner.editor.borrow().as_ref() {
             Some(editor) => {
                 let view = ComWrapper::new(WrapperView::new(self.inner.clone(), editor.clone()));
-                view.to_com_ptr::<IPlugView>().unwrap().into_raw()
+                let plug_view_ptr = view.to_com_ptr::<IPlugView>().unwrap().into_raw();
+                *self.inner.plug_view.write() = Some(view);
+                plug_view_ptr
             }
             None => std::ptr::null_mut(),
         }


### PR DESCRIPTION
Switch from the vst3-sys crate to the vst3 crate. With this change VST3 plugins built with NIH-plug no longer depend on the GPLv3 license.

Changes:
- This PR continues on the work from this draft PR: https://github.com/robbert-vdh/nih-plug/pull/243. This draft had some build issues on Linux and Windows that were fixed in this PR
-  This PR also handles the recent breaking change in Rust nightly where simd LaneCount was removed in favor of the #[rustc_simd_monomorphize_lane_limit] attribute: https://github.com/rust-lang/portable-simd/commit/8ce88bcb509e1f7d7b6b76724a6fcb827d9a78ac.


