### PR TITLE
Implement IPlugView::onKeyDown with Editor::on_key_down hook

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -69,6 +69,20 @@ pub trait Editor: Send {
     /// loaded.
     fn param_values_changed(&self);
 
+    /// Called when the host sends a key-down event to the plugin view (VST3
+    /// `IPlugView::onKeyDown`). Return `true` if the editor consumed the key
+    /// (the wrapper will return `kResultTrue` to the host so the host skips its
+    /// own accelerator handling); return `false` to let the host process the
+    /// key normally.
+    ///
+    /// This is primarily for text-input routing in hosts like REAPER that
+    /// intercept certain keys (space, Cmd-shortcuts) before they reach the
+    /// plugin's native view. The editor should only return `true` if a text
+    /// input in the editor currently has focus and can consume the character.
+    fn on_key_down(&self, _character: Option<char>) -> bool {
+        false
+    }
+
     // TODO: Reconsider adding a tick function here for the Linux `IRunLoop`. To keep this platform
     //       and API agnostic, add a way to ask the GuiContext if the wrapper already provides a
     //       tick function. If it does not, then the Editor implementation must handle this by

--- a/src/wrapper/vst3/view.rs
+++ b/src/wrapper/vst3/view.rs
@@ -338,11 +338,26 @@ impl<P: Vst3Plugin> IPlugView for WrapperView<P> {
 
     unsafe fn on_key_down(
         &self,
-        _key: vst3_sys::base::char16,
-        _key_code: i16,
+        key: vst3_sys::base::char16,
+        key_code: i16,
         _modifiers: i16,
     ) -> tresult {
-        kNotImplemented
+        // Only forward keys that carry a VST3 virtual key code. Those are
+        // keys the host (notably REAPER) may intercept as accelerators
+        // before they reach our native view — space, tab, return, arrows,
+        // etc. Plain printable characters arrive with `key_code = 0` and
+        // flow through the normal AppKit `keyDown:` path, which already
+        // handles text input via NSTextInputContext. Consuming them here
+        // would break letter input.
+        if key_code == 0 {
+            return kResultFalse;
+        }
+        let character = char::from_u32(key as u32);
+        if self.editor.lock().on_key_down(character) {
+            kResultOk
+        } else {
+            kResultFalse
+        }
     }
 
     unsafe fn on_key_up(


### PR DESCRIPTION
## Summary

Implements `IPlugView::onKeyDown` in the VST3 wrapper, forwarding to a new `Editor::on_key_down(Option<char>) -> bool` trait method. The editor returns `true` when it consumes the key (e.g. a text input has focus); the wrapper then returns `kResultOk` and the host skips its own accelerator. Otherwise the wrapper returns `kResultFalse` and the host processes the key normally.

## Motivation

On macOS REAPER, pressing space while a nih-plug plugin's text input has focus toggles REAPER's transport instead of inserting a space. This is because REAPER calls `IPlugView::onKeyDown` first for keys bound to its accelerator table; if the plugin returns `kResultTrue` REAPER skips the accelerator, if it returns `kNotImplemented` (nih-plug's current default) REAPER runs it.

This is a [long-standing issue in JUCE](https://forum.juce.com/t/reaper-stealing-spacebar-keystrokes-in-texteditor/30689) for the same reason — JUCE's VST3 wrapper also returns `kNotImplemented`. Commercial plugins that work in REAPER either use VSTGUI (which implements `onKeyDown`) or ship patched JUCE forks.

I verified the fix shape end-to-end with a probe JUCE plugin (applied the same override to `JuceVST3Editor`, observed space typed into a `juce::TextEditor`, no transport toggle, letters unaffected) before porting to nih-plug.

## Design notes

- **New trait method has a default impl returning `false`** so existing editors remain source-compatible.
- **Only keys with `key_code != 0` are forwarded.** VST3 populates `key_code` with a virtual key code for non-character keys (space → `KEY_SPACE=7`, return → `KEY_RETURN=2`, etc.) and leaves it zero for plain character keys. Character keys already reach the native view's `keyDown:` and are handled via `NSTextInputContext` — an earlier iteration that returned `kResultOk` on `key_code == 0` dropped all letter input.
- **Returns `kResultOk` on consume.** `vst3-sys` re-exports only `kResultOk`; the VST3 spec treats `kResultTrue` and `kResultOk` as identical.
- **Single-char signature is sufficient for the common case.** The trait could later gain virtual-key-code + modifiers for editors that want to handle arrow-key navigation, but `Option<char>` is enough to close the space-bar gap.

## Test

- Built a vizia-plug-backed plugin with a companion patch wiring `Editor::on_key_down` into the focused textbox.
- Loaded in REAPER 7.x on macOS 15 (Apple Silicon).
- Space with textbox focused → inserted, transport unchanged.
- Space with no textbox focus → transport toggles as before.
- Letter input → unchanged with and without textbox focus.
- Escape / arrows with no text focus → still reach the host.

## Companion work

A vizia-plug implementation of `Editor::on_key_down` lives at [`paravozz/vizia-plug#fix/vst3-on-key-down`](https://github.com/paravozz/vizia-plug/tree/fix/vst3-on-key-down). I'll open it as a PR against `vizia/vizia-plug` once this trait method lands so it has a real API to implement against.