### PR TITLE
nih_plug_egui: fix editor shrinking to a fraction of its size on HiDPI

### DIFF
--- a/nih_plug_egui/src/editor.rs
+++ b/nih_plug_egui/src/editor.rs
@@ -4,7 +4,6 @@ use crate::egui::Vec2;
 use crate::egui::ViewportCommand;
 use crate::EguiState;
 use baseview::gl::GlConfig;
-use baseview::PhySize;
 use baseview::{Size, WindowHandle, WindowOpenOptions, WindowScalePolicy};
 use crossbeam::atomic::AtomicCell;
 use egui_baseview::egui::Context;
@@ -104,15 +103,25 @@ where
             Default::default(),
             state,
             move |egui_ctx, _queue, state| build(egui_ctx, &mut state.write()),
-            move |egui_ctx, queue, state| {
+            move |egui_ctx, _queue, state| {
                 let setter = ParamSetter::new(context.as_ref());
 
                 // If the window was requested to resize
                 if let Some(new_size) = egui_state.requested_size.swap(None) {
                     // Ask the plugin host to resize to self.size()
                     if context.request_resize() {
-                        // Resize the content of egui window
-                        queue.resize(PhySize::new(new_size.0, new_size.1));
+                        // NOTE: Don't touch the surface size here. `queue.resize()` takes
+                        //       *physical* pixels while `new_size` is in *logical* points, so on
+                        //       any display with a scale factor above 1 this shrank the GL surface
+                        //       by that factor. It was usually invisible, because the viewport
+                        //       command below resizes the real window and the `Resized` event that
+                        //       follows overwrites the surface size with the correct value before
+                        //       the next frame is drawn. It became permanent whenever that resize
+                        //       was a no-op -- a request for the size the window already has --
+                        //       since then no configure event arrives to correct it, and the GUI
+                        //       stays at a fraction of its size (in the bottom-left corner, under
+                        //       OpenGL) until the editor is reopened. The window's own resize
+                        //       event is the single source of truth for the surface size.
                         egui_ctx.send_viewport_cmd(ViewportCommand::InnerSize(Vec2::new(
                             new_size.0 as f32,
                             new_size.1 as f32,

--- a/nih_plug_egui/src/resizable_window.rs
+++ b/nih_plug_egui/src/resizable_window.rs
@@ -51,10 +51,16 @@ impl ResizableWindow {
                     .max(self.min_size);
 
                 if corner_response.dragged() {
-                    egui_state.set_requested_size((
-                        desired_size.x.round() as u32,
-                        desired_size.y.round() as u32,
-                    ));
+                    let requested_size =
+                        (desired_size.x.round() as u32, desired_size.y.round() as u32);
+
+                    // Only ask for a size the window doesn't already have. A drag that is
+                    // clamped by `min_size` otherwise re-requests the current size on every
+                    // frame, and a resize to the size already in force is a no-op the host
+                    // never reports back.
+                    if requested_size != egui_state.size() {
+                        egui_state.set_requested_size(requested_size);
+                    }
                 }
             }
 


### PR DESCRIPTION
## The bug

`EguiEditor::spawn`'s update closure passes the requested window size — which `EguiState` documents and stores in **logical points** — straight into `Queue::resize`, whose parameter is in **physical pixels**:

```rust
if let Some(new_size) = egui_state.requested_size.swap(None) {
    if context.request_resize() {
        queue.resize(PhySize::new(new_size.0, new_size.1));
```

On a display with a scale factor of N this sets the surface to 1/N of the window in each axis.

It is usually invisible. `ViewportCommand::InnerSize` on the next line resizes the real window, egui-baseview recomputes the screen rect from the surface size every frame, and the `Resized` event that follows the configure overwrites the bad value before the next frame is drawn.

It becomes **permanent** when that resize is a no-op — when the requested size is the size the window already has — because no configure event arrives and nothing corrects the surface. baseview filters those out by design:

```rust
if self.new_physical_size.is_some()
    || new_physical_size != self.window.window_info.physical_size()
```

And `ResizableWindow` produces exactly that case: it calls `set_requested_size` on every dragged frame, so a drag clamped at `min_size` re-requests the current size indefinitely. One frame after the clamp the editor drops to 1/N scale and stays there until it is reopened. Under OpenGL, whose origin is bottom-left, the shrunken content sits in the bottom-left corner of an otherwise empty window.

## Reproducing

A CLAP editor built on `ResizableWindow`, on X11 at scale 2. Drag the resize corner inward until it clamps at `min_size`, then keep dragging. Instrumented output from the editor's own update closure:

```
screen_rect=800.0x660.0pt  ppp=2.000  gl_surface=1600x1320px   <- drag reaches min_size
screen_rect=400.0x330.0pt  ppp=2.000  gl_surface=800x660px     <- next frame, and it stays here
```

`pixels_per_point` is a correct 2.000 on every frame, so this is not a scale-factor handshake problem — it is purely the units of that one call.

## The fix

Two commits' worth of change, in one commit:

- **Drop the `Queue::resize` call.** The window's own resize event is the single source of truth for the surface size, and it already carries the correct units. Scaling `new_size` by the scale factor here would also work, but there seems to be no reason for this code to hold a second opinion about the surface size — `ViewportCommand::InnerSize` already resizes the real window, and egui-baseview forwards that to `Window::resize`. The cost is that a resize takes effect one frame later than it used to.

- **Have `ResizableWindow` request only sizes the window doesn't already have.** A no-op resize can't be reported back by the host, so asking for one leaves the editor in whatever state the request put it in. This is worth doing independently of the above: it's the difference between a resize request per dragged frame and one per actual size change.

Either change alone fixes the symptom. Together they also cover the general case of any editor requesting a size it already has.

Happy to add a `CHANGELOG.md` entry under a `Fixed` heading if you'd like one — I left it out since the file says its main purpose is listing breaking changes, and this isn't one.