### PR TITLE
Keep latest plugin builds available

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,3 +102,54 @@ jobs:
         with:
           name: ${{ env.ARCHIVE_NAME }}
           path: ${{ env.ARCHIVE_NAME }}
+
+  publish:
+    name: Update latest builds
+    if: github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+    needs: package
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Create release archives
+        run: |
+          mkdir release
+
+          for artifact in artifacts/*; do
+            case "$(basename "$artifact")" in
+              *-ubuntu-22.04) platform=linux ;;
+              *-macos-universal) platform=macos-universal ;;
+              *-windows) platform=windows ;;
+              *) echo "Unexpected artifact: $artifact" >&2; exit 1 ;;
+            esac
+
+            (cd "$artifact" && zip -r "../../release/nih-plugs-$platform.zip" .)
+          done
+
+      - name: Update latest builds release
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git tag --force latest-builds "$GITHUB_SHA"
+          git push --force origin refs/tags/latest-builds
+
+          if gh release view latest-builds > /dev/null 2>&1; then
+            gh release edit latest-builds \
+              --title 'Latest builds' \
+              --notes "Automatically built from commit $GITHUB_SHA on $DEFAULT_BRANCH." \
+              --prerelease
+            gh release upload latest-builds release/*.zip --clobber
+          else
+            gh release create latest-builds release/*.zip \
+              --verify-tag \
+              --title 'Latest builds' \
+              --notes "Automatically built from commit $GITHUB_SHA on $DEFAULT_BRANCH." \
+              --prerelease \
+              --latest=false
+          fi

--- a/README.md
+++ b/README.md
@@ -30,13 +30,11 @@ quickly get started with NIH-plug.
 ## Plugins
 
 Check each plugin's readme file for more details on what the plugin actually
-does. You can download the development binaries for Linux, Windows and macOS
-from the [automated
-builds](https://github.com/robbert-vdh/nih-plug/actions/workflows/build.yml?query=branch%3Amaster)
-page. Or if you're not signed in on GitHub, then you can also find the latest
-nightly build
-[here](https://nightly.link/robbert-vdh/nih-plug/workflows/build/master). You
-may need to [disable Gatekeeper](https://disable-gatekeeper.github.io/) on macOS to be able to use
+does. You can download the latest development binaries for Linux, Windows and
+macOS from the [Latest
+builds](https://github.com/robbert-vdh/nih-plug/releases/tag/latest-builds)
+page. You may need to [disable
+Gatekeeper](https://disable-gatekeeper.github.io/) on macOS to be able to use
 the plugins.
 
 Scroll down for more information on the underlying plugin framework.


### PR DESCRIPTION
The build artifacts currently expire after GitHub’s retention period. This keeps the newest successful default-branch packages available in a rolling **Latest builds** release.

## What changes

- After all three packaging jobs succeed on the default branch, download their artifacts and publish stable Linux, Windows, and universal macOS ZIP assets.
- Move the `latest-builds` tag and update the existing prerelease instead of accumulating releases.
- Keep pull request, feature branch, tag, and manual builds artifact-only.
- Point the README download link at the persistent release page, replacing the Actions and nightly.link alternatives.

## Validation

- `actionlint .github/workflows/build.yml`
- Dry-run of archive discovery, platform naming, and ZIP layout for all three matrix artifacts
- `git diff --check`