### PR TITLE
Implement ProcessContext::set_parameter

### DIFF
--- a/src/context/process.rs
+++ b/src/context/process.rs
@@ -1,7 +1,7 @@
 //! A context passed during the process function.
 
 use super::PluginApi;
-use crate::prelude::{Plugin, PluginNoteEvent};
+use crate::prelude::{Param, Plugin, PluginNoteEvent};
 
 /// Contains both context data and callbacks the plugin can use during processing. Most notably this
 /// is how a plugin sends and receives note events, gets transport information, and accesses
@@ -92,10 +92,15 @@ pub trait ProcessContext<P: Plugin> {
     /// monophonic modulation when dropping the capacity down to 1.
     fn set_current_voice_capacity(&self, capacity: u32);
 
-    // TODO: Add this, this works similar to [GuiContext::set_parameter] but it adds the parameter
-    //       change to a queue (or directly to the VST3 plugin's parameter output queues) instead of
-    //       using main thread host automation (and all the locks involved there).
-    // fn set_parameter<P: Param>(&self, param: &P, value: P::Plain);
+    /// Inform the host that a parameter's value has changed, similar to
+    /// [`ParamSetter::set_parameter()`][crate::prelude::ParamSetter::set_parameter()], but
+    /// realtime-safe: instead of going through main-thread host automation (and the locks that
+    /// involves), the change is placed on a queue (or, on VST3, written to the host's parameter
+    /// output queue) that gets flushed at the end of the current processing block, the same way
+    /// outgoing note events are handled. This does not send a begin/end gesture since it does not
+    /// represent a user editing gesture, and the parameter's reported value will not be updated
+    /// until the queued change has been flushed.
+    fn set_parameter<Pa: Param>(&mut self, param: &Pa, value: Pa::Plain);
 }
 
 /// Information about the plugin's transport. Depending on the plugin API and the host not all

--- a/src/wrapper/clap/context.rs
+++ b/src/wrapper/clap/context.rs
@@ -9,8 +9,8 @@ use std::sync::Arc;
 use super::wrapper::{OutputParamEvent, Task, Wrapper};
 use crate::event_loop::EventLoop;
 use crate::prelude::{
-    ClapPlugin, GuiContext, InitContext, ParamPtr, PluginApi, PluginNoteEvent, ProcessContext,
-    RemoteControlsContext, RemoteControlsPage, RemoteControlsSection, Transport,
+    ClapPlugin, GuiContext, InitContext, Param, ParamPtr, PluginApi, PluginNoteEvent,
+    ProcessContext, RemoteControlsContext, RemoteControlsPage, RemoteControlsSection, Transport,
 };
 use crate::wrapper::util::strlcpy;
 
@@ -124,6 +124,27 @@ impl<P: ClapPlugin> ProcessContext<P> for WrapperProcessContext<'_, P> {
 
     fn set_current_voice_capacity(&self, capacity: u32) {
         self.wrapper.set_current_voice_capacity(capacity)
+    }
+
+    fn set_parameter<Pa: Param>(&mut self, param: &Pa, value: Pa::Plain) {
+        let ptr = param.as_ptr();
+        match self.wrapper.param_ptr_to_hash.get(&ptr) {
+            Some(hash) => {
+                let normalized = param.preview_normalized(value);
+                let clap_plain_value = normalized as f64 * param.step_count().unwrap_or(1) as f64;
+                let success = self.wrapper.queue_parameter_event(OutputParamEvent::SetValue {
+                    param_hash: *hash,
+                    clap_plain_value,
+                });
+
+                nih_debug_assert!(
+                    success,
+                    "Parameter output event queue was full, parameter change will not be sent to \
+                     the host"
+                );
+            }
+            None => nih_debug_assert_failure!("Unknown parameter: {:?}", ptr),
+        }
     }
 }
 

--- a/src/wrapper/standalone/context.rs
+++ b/src/wrapper/standalone/context.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use super::backend::Backend;
 use super::wrapper::{Task, Wrapper};
 use crate::prelude::{
-    GuiContext, InitContext, ParamPtr, Plugin, PluginApi, PluginNoteEvent, ProcessContext,
+    GuiContext, InitContext, Param, ParamPtr, Plugin, PluginApi, PluginNoteEvent, ProcessContext,
     Transport,
 };
 
@@ -96,6 +96,12 @@ impl<P: Plugin, B: Backend<P>> ProcessContext<P> for WrapperProcessContext<'_, P
 
     fn set_current_voice_capacity(&self, _capacity: u32) {
         // This is only supported by CLAP
+    }
+
+    fn set_parameter<Pa: Param>(&mut self, param: &Pa, value: Pa::Plain) {
+        let ptr = param.as_ptr();
+        let normalized = param.preview_normalized(value);
+        self.wrapper.set_parameter(ptr, normalized);
     }
 }
 

--- a/src/wrapper/vst3/context.rs
+++ b/src/wrapper/vst3/context.rs
@@ -10,7 +10,7 @@ use crate::prelude::{
     Transport, Vst3Plugin,
 };
 
-use super::inner::{Task, WrapperInner};
+use super::inner::{OutputParamEvent, Task, WrapperInner};
 
 /// An [`InitContext`] implementation for the wrapper.
 ///
@@ -41,6 +41,7 @@ pub(crate) struct WrapperProcessContext<'a, P: Vst3Plugin> {
     pub(super) inner: &'a WrapperInner<P>,
     pub(super) input_events_guard: AtomicRefMut<'a, VecDeque<PluginNoteEvent<P>>>,
     pub(super) output_events_guard: AtomicRefMut<'a, VecDeque<PluginNoteEvent<P>>>,
+    pub(super) output_parameter_events_guard: AtomicRefMut<'a, VecDeque<OutputParamEvent>>,
     pub(super) transport: Transport,
 }
 

--- a/src/wrapper/vst3/context.rs
+++ b/src/wrapper/vst3/context.rs
@@ -6,8 +6,8 @@ use std::sync::Arc;
 use vst3_sys::vst::IComponentHandler;
 
 use crate::prelude::{
-    GuiContext, InitContext, ParamPtr, PluginApi, PluginNoteEvent, PluginState, ProcessContext,
-    Transport, Vst3Plugin,
+    GuiContext, InitContext, Param, ParamPtr, PluginApi, PluginNoteEvent, PluginState,
+    ProcessContext, Transport, Vst3Plugin,
 };
 
 use super::inner::{OutputParamEvent, Task, WrapperInner};
@@ -116,6 +116,21 @@ impl<P: Vst3Plugin> ProcessContext<P> for WrapperProcessContext<'_, P> {
 
     fn set_current_voice_capacity(&self, _capacity: u32) {
         // This is only supported by CLAP
+    }
+
+    fn set_parameter<Pa: Param>(&mut self, param: &Pa, value: Pa::Plain) {
+        let ptr = param.as_ptr();
+        match self.inner.param_ptr_to_hash.get(&ptr) {
+            Some(hash) => {
+                let normalized = param.preview_normalized(value);
+                self.output_parameter_events_guard
+                    .push_back(OutputParamEvent {
+                        param_hash: *hash,
+                        normalized_value: normalized,
+                    });
+            }
+            None => nih_debug_assert_failure!("Unknown parameter: {:?}", ptr),
+        }
     }
 }
 

--- a/src/wrapper/vst3/inner.rs
+++ b/src/wrapper/vst3/inner.rs
@@ -92,6 +92,10 @@ pub(crate) struct WrapperInner<P: Vst3Plugin> {
     /// Stores any events the plugin has output during the current processing cycle, analogous to
     /// `input_events`.
     pub output_events: AtomicRefCell<VecDeque<PluginNoteEvent<P>>>,
+    /// Parameter changes queued by [`ProcessContext::set_parameter()`][crate::prelude::ProcessContext::set_parameter()]
+    /// during the current processing cycle. These are written to the host's output parameter
+    /// change queue and drained at the end of each processing block, analogous to `output_events`.
+    pub output_parameter_events: AtomicRefCell<VecDeque<OutputParamEvent>>,
     /// VST3 has several useful predefined note expressions, but for some reason they are the only
     /// note event type that don't have MIDI note ID and channel fields. So we need to keep track of
     /// the most recent VST3 note IDs we've seen, and then map those back to MIDI note IDs and
@@ -137,6 +141,17 @@ pub(crate) struct WrapperInner<P: Vst3Plugin> {
     /// having to add a setter function to the parameter (or even worse, have it be completely
     /// untyped).
     pub param_ptr_to_hash: HashMap<ParamPtr, u32>,
+}
+
+/// A parameter change queued by [`ProcessContext::set_parameter()`][crate::prelude::ProcessContext::set_parameter()],
+/// to be written to the host's output parameter change queue at the end of the current processing
+/// block.
+#[derive(Debug, Clone, Copy)]
+pub struct OutputParamEvent {
+    /// The internal hash for the parameter.
+    pub param_hash: u32,
+    /// The parameter's new normalized value.
+    pub normalized_value: f32,
 }
 
 /// Tasks that can be sent from the plugin to be executed on the main thread in a non-blocking
@@ -307,6 +322,7 @@ impl<P: Vst3Plugin> WrapperInner<P> {
             )),
             input_events: AtomicRefCell::new(VecDeque::with_capacity(1024)),
             output_events: AtomicRefCell::new(VecDeque::with_capacity(1024)),
+            output_parameter_events: AtomicRefCell::new(VecDeque::with_capacity(1024)),
             note_expression_controller: AtomicRefCell::new(NoteExpressionController::default()),
             process_events: AtomicRefCell::new(Vec::with_capacity(4096)),
             updated_state_sender,
@@ -377,6 +393,7 @@ impl<P: Vst3Plugin> WrapperInner<P> {
             inner: self,
             input_events_guard: self.input_events.borrow_mut(),
             output_events_guard: self.output_events.borrow_mut(),
+            output_parameter_events_guard: self.output_parameter_events.borrow_mut(),
             transport,
         }
     }

--- a/src/wrapper/vst3/wrapper.rs
+++ b/src/wrapper/vst3/wrapper.rs
@@ -1636,6 +1636,33 @@ impl<P: Vst3Plugin> IAudioProcessor for Wrapper<P> {
                     }
                 }
 
+                // Send any parameter changes output by the plugin during the process cycle
+                if let Some(param_changes) = data.output_param_changes.upgrade() {
+                    let mut output_parameter_events =
+                        self.inner.output_parameter_events.borrow_mut();
+                    while let Some(event) = output_parameter_events.pop_front() {
+                        let mut queue_index = 0i32;
+                        if let Some(queue) = param_changes
+                            .add_parameter_data(&event.param_hash, &mut queue_index)
+                            .upgrade()
+                        {
+                            let sample_offset = clamp_output_event_timing(
+                                block_start as u32,
+                                total_buffer_len as u32,
+                            );
+                            let mut point_index = 0i32;
+                            let result = queue.add_point(
+                                sample_offset as i32,
+                                event.normalized_value as f64,
+                                &mut point_index,
+                            );
+                            nih_debug_assert_eq!(result, kResultOk);
+                        } else {
+                            nih_debug_assert_failure!("Host did not return a parameter value queue");
+                        }
+                    }
+                }
+
                 // If our block ends at the end of the buffer then that means there are no more
                 // unprocessed (parameter) events. If there are more events, we'll just keep going
                 // through this process until we've processed the entire buffer.


### PR DESCRIPTION
This PR should superscede: https://github.com/robbert-vdh/nih-plug/pull/238/changes/d790ee55b7948af29429ea8a41ca9f29532d86bc

Adds a realtime-safe way for a plugin to report a parameter value change from inside Plugin::process(). (TODO in src/context/process.rs). Works like ParamSetter::set_parameter(), but skips main-thread host automation and its locks. The change is queued and flushed to the host at the end of the current processing block instead.

- CLAP: reuses the existing OutputParamEvent::SetValue queue already used by GuiContext (no begin/end gesture, since this isn't a user gesture).
- VST3: adds a new output parameter queue (VST3 had no output-side equivalent of the input parameter queue before), drained each block into the host's IParameterChanges via add_parameter_data/add_point.
- Standalone: forwards to the existing realtime-safe parameter queue.